### PR TITLE
PostHTTP rebuild, SegFault fix (fixes #8)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ endif ()
 file(GLOB source_files "src/*.cpp" "include/*.h" "include/*/*.h" "include/*/*/*.h" "include/*.hpp" "include/*/*.hpp" "src/*/*.cpp")
 add_executable(BeamMP-Server ${source_files})
     
-target_include_directories(BeamMP-Server PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+target_include_directories(BeamMP-Server PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> cpp-httplib)
 
 find_package(Lua REQUIRED)
 target_include_directories(BeamMP-Server PUBLIC ${LUA_INCLUDE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,13 +25,13 @@ endif ()
 file(GLOB source_files "src/*.cpp" "include/*.h" "include/*/*.h" "include/*/*/*.h" "include/*.hpp" "include/*/*.hpp" "src/*/*.cpp")
 add_executable(BeamMP-Server ${source_files})
     
-target_include_directories(BeamMP-Server PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> cpp-httplib)
+target_include_directories(BeamMP-Server PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 
 find_package(Lua REQUIRED)
 target_include_directories(BeamMP-Server PUBLIC ${LUA_INCLUDE_DIR})
 
 if (UNIX)
-    target_link_libraries(BeamMP-Server z pthread stdc++fs ${Boost_LINK_DIRS} ${LUA_LIBRARIES} curl dl)
+    target_link_libraries(BeamMP-Server z pthread stdc++fs ${Boost_LINK_DIRS} ${LUA_LIBRARIES} curl dl crypto ssl)
 elseif (WIN32)
     include(FindLua)
     find_package(ZLIB REQUIRED)

--- a/include/Curl/Http.h
+++ b/include/Curl/Http.h
@@ -7,5 +7,6 @@
 ///
 #pragma once
 #include <string>
+#include <unordered_map>
 std::string HttpRequest(const std::string& host, int port, const std::string& target);
-std::string PostHTTP(const std::string& host, int port, const std::string& target, const std::string& Fields, bool json);
+std::string PostHTTP(const std::string& host, const std::string& target, const std::unordered_map<std::string, std::string>& fields, const std::string& body, bool json);

--- a/include/Curl/Http.h
+++ b/include/Curl/Http.h
@@ -7,5 +7,5 @@
 ///
 #pragma once
 #include <string>
-std::string HttpRequest(const std::string& IP, int port);
-std::string PostHTTP(const std::string& IP, const std::string& Fields, bool json);
+std::string HttpRequest(const std::string& host, int port, const std::string& target);
+std::string PostHTTP(const std::string& host, int port, const std::string& target, const std::string& Fields, bool json);

--- a/src/Init/Heartbeat.cpp
+++ b/src/Init/Heartbeat.cpp
@@ -56,12 +56,12 @@ std::string RunPromise(const std::string& host, const std::string& target, const
         R = GenerateCall();
         if (!CustomIP.empty())
             R += "&ip=" + CustomIP;
-        T = RunPromise("https://beammp.com", "/heartbeatv2", R);
+        T = RunPromise("beammp.com", "/heartbeatv2", R);
 
         if (T.substr(0, 2) != "20") {
             //Backend system refused server startup!
             std::this_thread::sleep_for(std::chrono::seconds(10));
-            T = RunPromise("https://backup1.beammp.com", "/heartbeatv2", R);
+            T = RunPromise("backup1.beammp.com", "/heartbeatv2", R);
             if (T.substr(0, 2) != "20") {
                 warn("Backend system refused server! Server might not show in the public list");
             }

--- a/src/Init/Heartbeat.cpp
+++ b/src/Init/Heartbeat.cpp
@@ -77,7 +77,7 @@ std::string RunPromise(const std::string& host, const std::string& target, const
                 info(("Resumed authenticated session!"));
             isAuth = true;
         }
-        //std::this_thread::sleep_for(std::chrono::seconds(5));
+        std::this_thread::sleep_for(std::chrono::seconds(5));
     }
 }
 void HBInit() {

--- a/src/Init/Heartbeat.cpp
+++ b/src/Init/Heartbeat.cpp
@@ -36,8 +36,8 @@ std::string GenerateCall() {
         << "&desc=" << ServerDesc;
     return Ret.str();
 }
-std::string RunPromise(const std::string& IP, const std::string& R) {
-    std::packaged_task<std::string()> task([&] { return PostHTTP(IP, R, false); });
+std::string RunPromise(const std::string& host, const std::string& target, const std::string& R) {
+    std::packaged_task<std::string()> task([&] { return PostHTTP(host, 443, target, R, false); });
     std::future<std::string> f1 = task.get_future();
     std::thread t(std::move(task));
     t.detach();
@@ -56,14 +56,12 @@ std::string RunPromise(const std::string& IP, const std::string& R) {
         R = GenerateCall();
         if (!CustomIP.empty())
             R += "&ip=" + CustomIP;
-        std::string link = "https://beammp.com/heartbeatv2";
-        T = RunPromise(link, R);
+        T = RunPromise("https://beammp.com", "/heartbeatv2", R);
 
         if (T.substr(0, 2) != "20") {
             //Backend system refused server startup!
             std::this_thread::sleep_for(std::chrono::seconds(10));
-            std::string Backup = "https://backup1.beammp.com/heartbeatv2";
-            T = RunPromise(Backup, R);
+            T = RunPromise("https://backup1.beammp.com", "/heartbeatv2", R);
             if (T.substr(0, 2) != "20") {
                 warn("Backend system refused server! Server might not show in the public list");
             }

--- a/src/Init/Heartbeat.cpp
+++ b/src/Init/Heartbeat.cpp
@@ -77,7 +77,7 @@ std::string RunPromise(const std::string& host, const std::string& target, const
                 info(("Resumed authenticated session!"));
             isAuth = true;
         }
-        std::this_thread::sleep_for(std::chrono::seconds(5));
+        std::this_thread::sleep_for(std::chrono::seconds(10));
     }
 }
 void HBInit() {

--- a/src/Network/Auth.cpp
+++ b/src/Network/Auth.cpp
@@ -20,7 +20,7 @@
 
 std::string GetClientInfo(const std::string& PK) {
     if (!PK.empty()) {
-        return PostHTTP("https://auth.beammp.com", 443, "/pkToUser", R"({"key":")" + PK + "\"}", true);
+        return PostHTTP("auth.beammp.com", 443, "/pkToUser", R"({"key":")" + PK + "\"}", true);
     }
     return "";
 }

--- a/src/Network/Auth.cpp
+++ b/src/Network/Auth.cpp
@@ -20,7 +20,7 @@
 
 std::string GetClientInfo(const std::string& PK) {
     if (!PK.empty()) {
-        return PostHTTP("auth.beammp.com", 443, "/pkToUser", R"({"key":")" + PK + "\"}", true);
+        return PostHTTP("auth.beammp.com", "/pkToUser", {}, R"({"key":")" + PK + "\"}", true);
     }
     return "";
 }

--- a/src/Network/Auth.cpp
+++ b/src/Network/Auth.cpp
@@ -20,8 +20,7 @@
 
 std::string GetClientInfo(const std::string& PK) {
     if (!PK.empty()) {
-        return PostHTTP("https://auth.beammp.com/pkToUser", R"({"key":")" + PK + "\"}", true);
-        ;
+        return PostHTTP("https://auth.beammp.com", 443, "/pkToUser", R"({"key":")" + PK + "\"}", true);
     }
     return "";
 }

--- a/src/Network/Http.cpp
+++ b/src/Network/Http.cpp
@@ -54,9 +54,8 @@ std::string PostHTTP(const std::string& IP, const std::string& Fields, bool json
     CurlManager M;
     CURL* curl = M.Get();
     CURLcode res;
-    std::string readBuffer;
-    readBuffer.resize(1000, 0);
-
+    char readBuffer[5000];
+    
     Assert(curl);
     if (curl) {
         curl_easy_setopt(curl, CURLOPT_URL, IP.c_str());
@@ -65,7 +64,7 @@ std::string PostHTTP(const std::string& IP, const std::string& Fields, bool json
         curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, Fields.size());
         curl_easy_setopt(curl, CURLOPT_POSTFIELDS, Fields.c_str());
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
-        curl_easy_setopt(curl, CURLOPT_WRITEDATA, &readBuffer[0]);
+        curl_easy_setopt(curl, CURLOPT_WRITEDATA, &readBuffer);
         curl_easy_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
         curl_easy_setopt(curl, CURLOPT_TIMEOUT, 5);
         res = curl_easy_perform(curl);

--- a/src/Network/Http.cpp
+++ b/src/Network/Http.cpp
@@ -137,7 +137,7 @@ std::string PostHTTP(const std::string& host, const std::string& target, const s
 
     // used for reading
     beast::flat_buffer buffer;
-    http::response<http::dynamic_body> response;
+    http::response<http::string_body> response;
 
     http::read(stream, buffer, response);
 
@@ -152,7 +152,7 @@ std::string PostHTTP(const std::string& host, const std::string& target, const s
     std::string debug_response_str;
     std::getline(result, debug_response_str);
     debug("POST " + host + target + ": " + debug_response_str);
-    return result.str();
+    return std::string(response.body());
 
     /*} catch (const std::exception& e) {
         error(e.what());

--- a/src/Network/Http.cpp
+++ b/src/Network/Http.cpp
@@ -48,13 +48,14 @@ std::string HttpRequest(const std::string& IP, int port) {
 }
 
 std::string PostHTTP(const std::string& IP, const std::string& Fields, bool json) {
-    auto header = curl_slist { (char*)"Content-Type: application/json" };
+    auto header = curl_slist { (char*)"Content-Type: application/json", nullptr };
     static std::mutex Lock;
     std::scoped_lock Guard(Lock);
     CurlManager M;
     CURL* curl = M.Get();
     CURLcode res;
     std::string readBuffer;
+    readBuffer.resize(1000, 0);
 
     Assert(curl);
     if (curl) {
@@ -64,7 +65,7 @@ std::string PostHTTP(const std::string& IP, const std::string& Fields, bool json
         curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, Fields.size());
         curl_easy_setopt(curl, CURLOPT_POSTFIELDS, Fields.c_str());
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
-        curl_easy_setopt(curl, CURLOPT_WRITEDATA, &readBuffer);
+        curl_easy_setopt(curl, CURLOPT_WRITEDATA, &readBuffer[0]);
         curl_easy_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
         curl_easy_setopt(curl, CURLOPT_TIMEOUT, 5);
         res = curl_easy_perform(curl);

--- a/src/Network/Http.cpp
+++ b/src/Network/Http.cpp
@@ -30,7 +30,7 @@ static size_t WriteCallback(void* contents, size_t size, size_t nmemb, void* use
     return size * nmemb;
 }
 std::string HttpRequest(const std::string& IP, int port) {
-    static thread_local CurlManager M;
+    CurlManager M;
     std::string readBuffer;
     CURL* curl = M.Get();
     CURLcode res;
@@ -49,9 +49,9 @@ std::string HttpRequest(const std::string& IP, int port) {
 
 std::string PostHTTP(const std::string& IP, const std::string& Fields, bool json) {
     auto header = curl_slist { (char*)"Content-Type: application/json" };
-    static thread_local CurlManager M;
     static std::mutex Lock;
     std::scoped_lock Guard(Lock);
+    CurlManager M;
     CURL* curl = M.Get();
     CURLcode res;
     std::string readBuffer;

--- a/src/Network/Http.cpp
+++ b/src/Network/Http.cpp
@@ -10,25 +10,27 @@
 #include <curl/curl.h>
 #include <iostream>
 
-class CurlManager{
+class CurlManager {
 public:
-    CurlManager(){
+    CurlManager() {
         curl = curl_easy_init();
     }
-    ~CurlManager(){
+    ~CurlManager() {
         curl_easy_cleanup(curl);
     }
-    inline CURL* Get(){
+    inline CURL* Get() {
         return curl;
     }
+
 private:
-    CURL *curl;
+    CURL* curl;
 };
 
 static size_t WriteCallback(void* contents, size_t size, size_t nmemb, void* userp) {
-    ((std::string*)userp)->append((char*)contents, size * nmemb);
+    std::string((char*)userp).append((char*)contents, size * nmemb);
     return size * nmemb;
 }
+
 std::string HttpRequest(const std::string& IP, int port) {
     CurlManager M;
     std::string readBuffer;
@@ -55,7 +57,7 @@ std::string PostHTTP(const std::string& IP, const std::string& Fields, bool json
     CURL* curl = M.Get();
     CURLcode res;
     char readBuffer[5000];
-    
+
     Assert(curl);
     if (curl) {
         curl_easy_setopt(curl, CURLOPT_URL, IP.c_str());


### PR DESCRIPTION
Changes:
- `HttpRequest` & `PostHTTP` now use `boost::beast` instead of `libcurl`, which also means their signatures were changed drastically. Uses TLS 1.3 and IPv6 by default, switches to IPv4 if IPv6 fails
- Added a `DebugPrintTID()` to `RunPromise` for the heartbeat, properly identifying errors coming from heartbeat POST requests with the current thread in server Debug mode
- Added a "hot-change" heartbeat: If something changes in the server, it will heartbeat the changes at up to once every 5 seconds, 
- Fixed #8 

ToDo:
- Need to update the requirements documentation, we will need boost beast, SSL, crypto, ...
- Test windows build