### PR TITLE
Actions: Prerelease by default

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -24,7 +24,7 @@ jobs:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}
           draft: false
-          prerelease: false 
+          prerelease: true
           body: |
               Files included in this release:
               - `BeamMP-Server.exe` is the windows build


### PR DESCRIPTION
Since the Backend will change version numbers on release, we want to ensure that automated releases (on new-tag) don't trigger this mechanism. This patch makes automated releases pre-release by default, and can later manually be changed to "release". Not sure if manually changing a release from pre-release to actual release will trigger a webhook, we will have to test that. Worst-case we can just manually do real releases.