### PR TITLE
Enable macOS toolchain compatibility #66

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,9 @@ add_compile_definitions(CPPHTTPLIB_OPENSSL_SUPPORT __linux)
 if(APPLE)
     set(LUA_INCLUDE_DIR /usr/local/Cellar/lua@5.3/5.3.6/include/lua5.3)
     set(LUA_LIBRARIES lua)
+    include_directories(/usr/local/opt/openssl@1.1/include)
     link_directories(/usr/local/Cellar/lua@5.3/5.3.6/lib)
+    link_directories(/usr/local/opt/openssl@1.1/lib)
 endif()
 
 if (WIN32)
@@ -121,15 +123,16 @@ target_link_libraries(BeamMP-Server sol2::sol2 ${LUA_LIBRARIES})
 message(STATUS "CURL IS ${CURL_LIBRARIES}")
 
 if (UNIX)
-    target_link_libraries(BeamMP-Server 
+    target_link_libraries(BeamMP-Server
         z 
-        pthread 
-        stdc++fs 
+        pthread
         ${LUA_LIBRARIES} 
         crypto
         ${OPENSSL_LIBRARIES} 
         commandline 
-        sentry)
+        sentry
+        ssl
+            )
 elseif (WIN32)
     include(FindLua)
     message(STATUS "Looking for libz")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,13 @@ include_directories("${PROJECT_SOURCE_DIR}/deps/sol2/include")
 include_directories("${PROJECT_SOURCE_DIR}/deps/cpp-httplib")
 include_directories("${PROJECT_SOURCE_DIR}/deps")
 
-add_compile_definitions(CPPHTTPLIB_OPENSSL_SUPPORT)
+add_compile_definitions(CPPHTTPLIB_OPENSSL_SUPPORT __linux)
+
+if(APPLE)
+    set(LUA_INCLUDE_DIR /usr/local/Cellar/lua@5.3/5.3.6/include/lua5.3)
+    set(LUA_LIBRARIES lua)
+    link_directories(/usr/local/Cellar/lua@5.3/5.3.6/lib)
+endif()
 
 if (WIN32)
     # this has to happen before sentry, so that crashpad on windows links with these settings.
@@ -99,7 +105,7 @@ target_include_directories(BeamMP-Server PUBLIC
     "${CMAKE_CURRENT_SOURCE_DIR}/commandline")
 
 message(STATUS "Looking for Lua")
-find_package(Lua REQUIRED VERSION 5.3)
+# find_package(Lua REQUIRED VERSION 5.3)
 target_include_directories(BeamMP-Server PUBLIC 
     ${LUA_INCLUDE_DIR} 
     ${CURL_INCLUDE_DIRS}
@@ -109,7 +115,7 @@ target_include_directories(BeamMP-Server PUBLIC
 
 message(STATUS "Looking for SSL")
 
-find_package(OpenSSL REQUIRED)
+# find_package(OpenSSL REQUIRED)
 
 target_link_libraries(BeamMP-Server sol2::sol2 ${LUA_LIBRARIES})
 message(STATUS "CURL IS ${CURL_LIBRARIES}")

--- a/include/Compat.h
+++ b/include/Compat.h
@@ -19,6 +19,23 @@ inline void CloseSocketProper(int TheSocket) {
 }
 #endif // unix
 
+#ifdef __APPLE__
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <termios.h>
+#include <unistd.h>
+#include <errno.h>
+using SOCKET = int;
+using DWORD = unsigned long;
+using PDWORD = unsigned long*;
+using LPDWORD = unsigned long*;
+char _getch();
+inline void CloseSocketProper(int TheSocket) {
+    shutdown(TheSocket, SHUT_RDWR);
+    close(TheSocket);
+}
+#endif // unix
+
 // ======================= WIN32 =======================
 
 #ifdef WIN32
@@ -33,6 +50,6 @@ inline void CloseSocketProper(SOCKET TheSocket) {
 
 // ======================= OTHER =======================
 
-#if !defined(WIN32) && !defined(__unix)
+#if !defined(WIN32) && !defined(__unix) && !defined(__APPLE__)
 #error "OS not supported"
 #endif

--- a/include/TLuaEngine.h
+++ b/include/TLuaEngine.h
@@ -32,7 +32,7 @@ struct TLuaResult {
     std::atomic_bool Ready;
     std::atomic_bool Error;
     std::string ErrorMessage;
-    sol::object Result { sol::nil };
+    sol::object Result { sol::lua_nil };
     TLuaStateId StateId;
     std::string Function;
     // TODO: Add condition_variable

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -117,6 +117,8 @@ void RegisterThread(const std::string& str) {
     std::string ThreadId;
 #ifdef WIN32
     ThreadId = std::to_string(GetCurrentThreadId());
+#elif __APPLE__
+    ThreadId = std::to_string(getpid());
 #else
     ThreadId = std::to_string(gettid());
 #endif

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -118,7 +118,7 @@ void RegisterThread(const std::string& str) {
 #ifdef WIN32
     ThreadId = std::to_string(GetCurrentThreadId());
 #elif __APPLE__
-    ThreadId = std::to_string(getpid());
+    ThreadId = std::to_string(getpid()); // todo: research if 'getpid()' is a valid, posix compliant alternative to 'gettid()'
 #else
     ThreadId = std::to_string(gettid());
 #endif

--- a/src/LuaAPI.cpp
+++ b/src/LuaAPI.cpp
@@ -42,7 +42,7 @@ static std::string LuaToString(const sol::object Value, size_t Indent = 1, bool 
         ss << Value.as<float>();
         return ss.str();
     }
-    case sol::type::nil:
+    case sol::type::lua_nil:
     case sol::type::none:
         return "<nil>";
     case sol::type::boolean:

--- a/src/SignalHandling.cpp
+++ b/src/SignalHandling.cpp
@@ -1,7 +1,7 @@
 #include "SignalHandling.h"
 #include "Common.h"
 
-#ifdef __unix
+#if defined(__unix) || defined(__linux) || defined(__APPLE__)
 #include <csignal>
 static void UnixSignalHandler(int sig) {
     switch (sig) {
@@ -48,7 +48,7 @@ BOOL WINAPI Win32CtrlC_Handler(DWORD CtrlType) {
 
 void SetupSignalHandlers() {
     // signal handlers for unix#include <windows.h>
-#if defined(__unix) || defined(__linux)
+#if defined(__unix) || defined(__linux) || defined(__APPLE__)
     beammp_trace("registering handlers for signals");
     signal(SIGPIPE, UnixSignalHandler);
     signal(SIGTERM, UnixSignalHandler);

--- a/src/TLuaEngine.cpp
+++ b/src/TLuaEngine.cpp
@@ -281,7 +281,7 @@ sol::table TLuaEngine::StateThreadData::Lua_TriggerGlobalEvent(const std::string
             auto Vector = Self.get<std::vector<std::shared_ptr<TLuaResult>>>("ReturnValueImpl");
             for (const auto& Value : Vector) {
                 if (!Value->Ready) {
-                    return sol::nil;
+                    return sol::lua_nil;
                 }
                 Result.add(Value->Result);
             }
@@ -313,7 +313,7 @@ sol::table TLuaEngine::StateThreadData::Lua_GetPlayerIdentifiers(int ID) {
     if (MaybeClient && !MaybeClient.value().expired()) {
         auto IDs = MaybeClient.value().lock()->GetIdentifiers();
         if (IDs.empty()) {
-            return sol::nil;
+            return sol::lua_nil;
         }
         sol::table Result = mStateView.create_table();
         for (const auto& Pair : IDs) {
@@ -321,7 +321,7 @@ sol::table TLuaEngine::StateThreadData::Lua_GetPlayerIdentifiers(int ID) {
         }
         return Result;
     } else {
-        return sol::nil;
+        return sol::lua_nil;
     }
 }
 
@@ -356,7 +356,7 @@ sol::table TLuaEngine::StateThreadData::Lua_GetPlayerVehicles(int ID) {
             VehicleData = *LockedData.VehicleData;
         } // End Vehicle Data Lock Scope
         if (VehicleData.empty()) {
-            return sol::nil;
+            return sol::lua_nil;
         }
         sol::state_view StateView(mState);
         sol::table Result = StateView.create_table();
@@ -365,7 +365,7 @@ sol::table TLuaEngine::StateThreadData::Lua_GetPlayerVehicles(int ID) {
         }
         return Result;
     } else
-        return sol::nil;
+        return sol::lua_nil;
 }
 
 sol::table TLuaEngine::StateThreadData::Lua_HttpCreateConnection(const std::string& host, uint16_t port) {


### PR DESCRIPTION
#66 
This should bring in various definitions and changes to enable macOS toolchain compatibility on Monterey.
Users can install Lua 5.3 via brew and, assuming their cellar paths are default, should be able to compile the project
with the default cmakeliststxt.

Warning: This is pretty shoddy and will likely break on the next major macOS Update.