### PR TITLE
fix: broken .gitmodules file

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
-[submodule "deps/https:/github.com/chriskohlhoff/asio"]
-	path = deps/https:/github.com/chriskohlhoff/asio
+[submodule "deps/commandline"]
+	path = deps/commandline
 	url = https://github.com/lionkor/commandline
 [submodule "deps/asio"]
 	path = deps/asio
@@ -22,6 +22,3 @@
 [submodule "deps/cpp-httplib"]
 	path = deps/cpp-httplib
 	url = https://github.com/yhirose/cpp-httplib
-[submodule "deps/commandline"]
-	path = deps/commandline
-	url = git@github.com:/lionkor/commandline


### PR DESCRIPTION
**Current Situation**
I wanted to test the new http endpoint feature.
I noticed that the docker build failed because it could not clone some dependencies.

After looking at the `.gitmodules` file I realized why, it was broken and used ssh instead of http links.

**Expected Situation**
`.gitmodules` file is fixed.

I tried to fix it in my PR, but please have a look.