### PR TITLE
Feature: Better autocomplete

### DIFF
--- a/include/TLuaEngine.h
+++ b/include/TLuaEngine.h
@@ -96,6 +96,13 @@ public:
         std::unique_lock Lock(mLuaStatesMutex);
         return mLuaStates.size();
     }
+    std::vector<std::string> GetLuaStateNames() {
+        std::vector<std::string> names{};
+        for(auto const& [stateId, _ ] : mLuaStates) {
+            names.push_back(stateId);
+        }
+        return names;
+    }
     size_t GetTimedEventsCount() {
         std::unique_lock Lock(mTimedEventsMutex);
         return mTimedEvents.size();
@@ -172,6 +179,7 @@ public:
     static constexpr const char* BeamMPFnNotFoundError = "BEAMMP_FN_NOT_FOUND";
 
     std::vector<std::string> GetStateGlobalKeysForState(TLuaStateId StateId);
+    std::vector<std::string> GetStateTableKeysForState(TLuaStateId StateId, std::vector<std::string> keys);
 
     // Debugging functions (slow)
     std::unordered_map<std::string /*event name */, std::vector<std::string> /* handlers */> Debug_GetEventsForState(TLuaStateId StateId);
@@ -199,6 +207,7 @@ private:
         sol::state_view State() { return sol::state_view(mState); }
 
         std::vector<std::string> GetStateGlobalKeys();
+        std::vector<std::string> GetStateTableKeys(const std::vector<std::string>& keys);
 
         // Debug functions, slow
         std::queue<std::pair<TLuaChunk, std::shared_ptr<TLuaResult>>> Debug_GetStateExecuteQueue();

--- a/src/Compat.cpp
+++ b/src/Compat.cpp
@@ -36,7 +36,14 @@ TEST_CASE("init and reset termios") {
         resetTermios();
         struct termios current;
         tcgetattr(0, &current);
-        CHECK(std::memcmp(&original, &current, sizeof(struct termios)) == 0);
+        CHECK_EQ(std::memcmp(&current.c_cc, &original.c_cc, sizeof(current.c_cc)), 0);
+        CHECK_EQ(current.c_cflag, original.c_cflag);
+        CHECK_EQ(current.c_iflag, original.c_iflag);
+        CHECK_EQ(current.c_ispeed, original.c_ispeed);
+        CHECK_EQ(current.c_lflag, original.c_lflag);
+        CHECK_EQ(current.c_line, original.c_line);
+        CHECK_EQ(current.c_oflag, original.c_oflag);
+        CHECK_EQ(current.c_ospeed, original.c_ospeed);
     }
 }
 

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -51,6 +51,18 @@ TEST_CASE("TrimString") {
     CHECK(TrimString("") == "");
 }
 
+// TODO: add unit tests to SplitString
+static inline void SplitString(std::string const& str, const char delim, std::vector<std::string>& out) {
+    size_t start;
+    size_t end = 0;
+
+    while ((start = str.find_first_not_of(delim, end)) != std::string::npos) {
+        end = str.find(delim, start);
+        out.push_back(str.substr(start, end - start));
+    }
+}
+
+
 std::string GetDate() {
     std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
     time_t tt = std::chrono::system_clock::to_time_t(now);
@@ -618,45 +630,70 @@ TConsole::TConsole() {
             beammp_error("Console died with: " + std::string(e.what()) + ". This could be a fatal error and could cause the server to terminate.");
         }
     };
-    mCommandline.on_autocomplete = [this](Commandline&, std::string stub, int) {
+    mCommandline.on_autocomplete = [this](Commandline& c, std::string stub, int cursorPos) {
         std::vector<std::string> suggestions;
         try {
-            auto cmd = TrimString(stub);
-            // beammp_error("yes 1");
-            // beammp_error(stub);
             if (mIsLuaConsole) { // if lua
                 if (!mLuaEngine) {
                     beammp_info("Lua not started yet, please try again in a second");
                 } else {
-                    std::string prefix {};
-                    for (size_t i = stub.length(); i > 0; i--) {
-                        if (!std::isalnum(stub[i - 1]) && stub[i - 1] != '_') {
+                    std::string prefix {}; // stores non-table part of input
+                    for (size_t i = stub.length(); i > 0; i--) { //separate table from input
+                        if (!std::isalnum(stub[i - 1]) && stub[i - 1] != '_' && stub[i - 1] != '.') {
                             prefix = stub.substr(0, i);
                             stub = stub.substr(i);
                             break;
                         }
                     }
-                    auto keys = mLuaEngine->GetStateGlobalKeysForState(mStateId);
-                    for (const auto& key : keys) {
-                        std::string::size_type n = key.find(stub);
+
+                    // turn string into vector of keys
+                    std::vector<std::string> tablekeys;
+
+                    SplitString(stub, '.', tablekeys);
+
+                    // remove last key if incomplete
+                    if (stub.rfind('.') != stub.size() - 1 && !tablekeys.empty()) {
+                        tablekeys.pop_back();
+                    }
+
+                    auto keys = mLuaEngine->GetStateTableKeysForState(mStateId, tablekeys);
+
+                    for (const auto& key : keys) { // go through each bottom-level key
+                        auto last_dot = stub.rfind('.');
+                        std::string last_atom;
+                        if (last_dot != std::string::npos) {
+                            last_atom = stub.substr(last_dot + 1);
+                        }
+                        std::string before_last_atom = stub.substr(0, last_dot + 1); // get last confirmed key
+                        auto last = stub.substr(stub.rfind('.') + 1);
+                        std::string::size_type n = key.find(last);
                         if (n == 0) {
-                            suggestions.push_back(prefix + key);
-                            // beammp_warn(cmd_name);
+                            suggestions.push_back(prefix + before_last_atom + key);
                         }
                     }
                 }
             } else { // if not lua
-                for (const auto& [cmd_name, cmd_fn] : mCommandMap) {
-                    std::string::size_type n = cmd_name.find(stub);
-                    if (n == 0) {
-                        suggestions.push_back(cmd_name);
-                        // beammp_warn(cmd_name);
+                if (stub.find("lua") == 0) { // starts with "lua" means we should suggest state names
+                    std::string after_prefix = TrimString(stub.substr(3));
+                    auto stateNames = mLuaEngine->GetLuaStateNames();
+
+                    for (const auto& name : stateNames) {
+                        if (name.find(after_prefix) == 0) {
+                            suggestions.push_back("lua " + name);
+                        }
+                    }
+                } else {
+                    for (const auto& [cmd_name, cmd_fn] : mCommandMap) {
+                        if (cmd_name.find(stub) == 0) {
+                            suggestions.push_back(cmd_name);
+                        }
                     }
                 }
             }
         } catch (const std::exception& e) {
             beammp_error("Console died with: " + std::string(e.what()) + ". This could be a fatal error and could cause the server to terminate.");
         }
+        std::sort(suggestions.begin(), suggestions.end());
         return suggestions;
     };
 }

--- a/src/TLuaEngine.cpp
+++ b/src/TLuaEngine.cpp
@@ -221,6 +221,66 @@ std::vector<std::string> TLuaEngine::StateThreadData::GetStateGlobalKeys() {
     return Result;
 }
 
+std::vector<std::string> TLuaEngine::GetStateTableKeysForState(TLuaStateId StateId, std::vector<std::string> keys) {
+    std::unique_lock Lock(mLuaStatesMutex);
+    auto Result = mLuaStates.at(StateId)->GetStateTableKeys(keys);
+    return Result;
+}
+
+std::vector<std::string> TLuaEngine::StateThreadData::GetStateTableKeys(const std::vector<std::string>& keys) {
+    auto globals = mStateView.globals();
+
+    sol::table current = globals;
+    std::vector<std::string> Result {};
+
+    for (const auto& [key, value] : current) {
+        std::string s = key.as<std::string>();
+        if (value.get_type() == sol::type::function) {
+            s += "(";
+        }
+        Result.push_back(s);
+    }
+
+    if (!keys.empty()) {
+        Result.clear();
+    }
+
+    for (size_t i = 0; i < keys.size(); ++i) {
+        auto obj = current.get<sol::object>(keys.at(i));
+        if (obj.get_type() == sol::type::nil) {
+            // error
+            break;
+        } else if (i == keys.size() - 1) {
+            if (obj.get_type() == sol::type::table) {
+                for (const auto& [key, value] : obj.as<sol::table>()) {
+                    std::string s = key.as<std::string>();
+                    if (value.get_type() == sol::type::function) {
+                        s += "(";
+                    }
+                    Result.push_back(s);
+                }
+            } else {
+                Result = { obj.as<std::string>() };
+            }
+            break;
+        }
+        if (obj.get_type() == sol::type::table) {
+            current = obj;
+        } else {
+            // error
+            break;
+        }
+    }
+
+    return Result;
+}
+
+/*
+
+    _G.a.b.c.d.
+
+*/
+
 void TLuaEngine::WaitForAll(std::vector<std::shared_ptr<TLuaResult>>& Results, const std::optional<std::chrono::high_resolution_clock::duration>& Max) {
     for (const auto& Result : Results) {
         bool Cancelled = false;


### PR DESCRIPTION
This feature, built by @20dka and me, allows the console's autocomplete to complete table members.

For example, typing:

```
lua> Util.
```

and then pressing *TAB*, will suggest (as the first completion):

```
lua> Util.JsonDecode(
```
and further TAB presses will cycle through JsonDiff(, JsonDecode(, and so on. 
This works for all tables, **including user-defined tables** like any tables from plugins, and any other symbols (like  functions, globals, ...). 

This is a powerful addition to the "attach and debug" workflow.