### PR TITLE
Static build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,10 +90,27 @@ add_subdirectory(deps)
 
 # ------------------------ VARIABLES ---------------------------------
 
-include(FindLua)
+option(FIND_OPENSSL "Whether or not to find openssl automatically (keep on unless you know what you're doing)" ON)
+option(FIND_ZLIB "Whether or not to find zlib automatically (keep on unless you know what you're doing)" ON)
+
 include(FindOpenSSL)
+if (${FIND_OPENSSL})
+    set(OPENSSL_CRYPTO OpenSSL::Crypto)
+    set(OPENSSL_SSL OpenSSL::SSL)
+else()
+    message(STATUS "Using custom openssl libs: ${OPENSSL_CRYPTO} ${OPENSSL_SSL}")
+endif()
+
+include(FindLua)
 include(FindThreads)
+
 include(FindZLIB)
+
+if (${FIND_ZLIB})
+    set(ZLIB_ZLIB ZLIB::ZLIB)
+else()
+    message(STATUS "Using custom zlib: ${ZLIB_ZLIB}")
+endif()
 
 set(BeamMP_Sources
     include/TConsole.h src/TConsole.cpp
@@ -171,12 +188,12 @@ endif()
 
 set(BeamMP_Libraries
     doctest::doctest
-    OpenSSL::SSL
-    OpenSSL::Crypto
+    ${OPENSSL_SSL}
+    ${OPENSSL_CRYPTO}
     sol2::sol2
     fmt::fmt
     Threads::Threads
-    ZLIB::ZLIB
+    ${ZLIB_ZLIB}
     ${LUA_LIBRARIES}
     commandline
     sentry

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM lionkor/alpine-static-cpp:latest
+
+RUN apk update && apk --no-cache add python3 git lua zlib-static openssl curl rapidjson curl-dev wget
+RUN apk --no-cache add openssl-libs-static curl-static
+
+RUN wget "https://www.lua.org/ftp/lua-5.4.4.tar.gz"; tar xzvf lua-5.4.4.tar.gz; mv lua-5.4.4 /lua; rm lua-5.4.4.tar.gz
+
+RUN cd /lua; make all -j; cd ..
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM lionkor/alpine-static-cpp:latest
 
-RUN apk update && apk --no-cache add python3 git lua zlib-static openssl curl rapidjson curl-dev wget
-RUN apk --no-cache add openssl-libs-static curl-static
+ARG LUA_V=5.3.6
 
-RUN wget "https://www.lua.org/ftp/lua-5.4.4.tar.gz"; tar xzvf lua-5.4.4.tar.gz; mv lua-5.4.4 /lua; rm lua-5.4.4.tar.gz
+RUN apk update && apk --no-cache add python3 git lua zlib-static openssl curl rapidjson curl-dev wget readline-static
+RUN apk --no-cache add openssl-libs-static curl-static readline-dev
 
-RUN cd /lua; make all -j; cd ..
+RUN wget "https://www.lua.org/ftp/lua-${LUA_V}.tar.gz"; tar xzvf lua-${LUA_V}.tar.gz; mv "lua-${LUA_V}" /lua; rm lua-${LUA_V}.tar.gz
+
+RUN cd /lua; make all -j linux; cd ..
 

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,10 +1,22 @@
 #!/bin/sh
 
+# usage:
+# ./docker-build.sh
+#       builds the image, and then runs it
+# ./docker-build.sh run
+#       only runs it
+
 set -e
 
-git submodule update --init --recursive
+if [ "$1" != "run" ]
+then
+    git submodule update --init --recursive
+    docker build . --tag beammp-static
+fi
 
-docker build . --tag beammp-static
 
 docker run -v $(pwd):/root -it --rm beammp-static sh -c "cd root; cmake . -B build -DGIT_SUBMODULE=OFF -DLUA_INCLUDE_DIR=/lua/src -DSOL2_SINGLE=ON -DFIND_OPENSSL=OFF -DOPENSSL_CRYPTO=\"/usr/lib/libcrypto.a\" -DOPENSSL_SSL=\"/usr/lib/libssl.a\" -DFIND_ZLIB=OFF -DZLIB_ZLIB=/lib/libz.a -DCURL_FOUND=ON -DCURL_LIBRARIES=\"/usr/lib/libcurl.a\" -DLUA_LIBRARIES=\"/lua/src/liblua.a\" -DSENTRY_BACKEND=none -DSENTRY_TRANSPORT=none; make -C build -j BeamMP-Server"
+
+# try to chown the build directory afterwards
+sudo chown -R "$USER":"$USER" build
 

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+git submodule update --init --recursive
+
+docker build . --tag beammp-static
+
+docker run -v $(pwd):/root -it --rm beammp-static sh -c "cd root; cmake . -B build -DGIT_SUBMODULE=OFF -DLUA_INCLUDE_DIR=/lua/src -DSOL2_SINGLE=ON -DFIND_OPENSSL=OFF -DOPENSSL_CRYPTO=\"/usr/lib/libcrypto.a\" -DOPENSSL_SSL=\"/usr/lib/libssl.a\" -DFIND_ZLIB=OFF -DZLIB_ZLIB=/lib/libz.a -DCURL_FOUND=ON -DCURL_LIBRARIES=\"/usr/lib/libcurl.a\" -DLUA_LIBRARIES=\"/lua/src/liblua.a\" -DSENTRY_BACKEND=none -DSENTRY_TRANSPORT=none; make -C build -j BeamMP-Server"
+


### PR DESCRIPTION
Statically builds the BeamMP-Server (without sentry) via a docker image and some magic.

This means that a BeamMP-Server built with this method will run on any current Linux distribution (x86_64) **without** any dependencies required (or the stupid GLIBC_* error).