### PR TITLE
Launcher v3.x compatibility

### DIFF
--- a/include/Common.h
+++ b/include/Common.h
@@ -80,7 +80,7 @@ public:
     static TConsole& Console() { return *mConsole; }
     static std::string ServerVersionString();
     static const Version& ServerVersion() { return mVersion; }
-    static std::string ClientVersionString() { return "2.0"; }
+    static std::string ClientVersionString() { return "3.0"; }
     static std::string PPS() { return mPPS; }
     static void SetPPS(const std::string& NewPPS) { mPPS = NewPPS; }
 


### PR DESCRIPTION
Do not merge until Launcher v3.x is publically released.