### PR TITLE
network and console improvements

### DIFF
--- a/include/TConsole.h
+++ b/include/TConsole.h
@@ -38,6 +38,10 @@ private:
     void Command_Clear(const std::string&, const std::vector<std::string>& args);
     void Command_Debug(const std::string&, const std::vector<std::string>& args);
 
+    void Autocomplete_Lua(const std::string&, std::vector<std::string>& suggestions);
+    void Autocomplete_Kick(const std::string&, std::vector<std::string>& suggestions);
+    void Autocomplete_Settings(const std::string&, std::vector<std::string>& suggestions);
+
     void Command_Say(const std::string& FullCommand);
     bool EnsureArgsCount(const std::vector<std::string>& args, size_t n);
     bool EnsureArgsCount(const std::vector<std::string>& args, size_t min, size_t max);
@@ -56,6 +60,12 @@ private:
         { "debug", [this](const auto& a, const auto& b) { Command_Debug(a, b); } },
         { "say", [this](const auto&, const auto&) { Command_Say(""); } }, // shouldn't actually be called
     };
+
+    std::unordered_map<std::string, std::function<void(const std::string&, std::vector<std::string>&)>> mCommandAutocompleteMap = {
+        { "lua", [this](const auto& a, auto& b) { Autocomplete_Lua(a, b); } },
+        { "kick", [this](const auto& a, auto& b) { Autocomplete_Kick(a, b); } },
+        { "settings", [this](const auto& a, auto& b) { Autocomplete_Settings(a, b); } },
+	};
 
     Commandline mCommandline;
     std::vector<std::string> mCachedLuaHistory;

--- a/include/TServer.h
+++ b/include/TServer.h
@@ -26,7 +26,7 @@ public:
     void ForEachClient(const std::function<bool(std::weak_ptr<TClient>)>& Fn);
     size_t ClientCount() const;
 
-    static void GlobalParser(const std::weak_ptr<TClient>& Client, std::vector<uint8_t>&& Packet, TPPSMonitor& PPSMonitor, TNetwork& Network);
+    static void GlobalParser(const std::weak_ptr<TClient>& Client, std::vector<uint8_t>&& Packet, TNetwork& Network);
     static void HandleEvent(TClient& c, const std::string& Data);
     RWMutex& GetClientMutex() const { return mClientsMutex; }
 

--- a/include/TServer.h
+++ b/include/TServer.h
@@ -44,6 +44,7 @@ private:
     static bool IsUnicycle(TClient& c, const std::string& CarJson);
     static void Apply(TClient& c, int VID, const std::string& pckt);
     static bool HandlePosition(TClient& c, const std::string& Packet);
+    static bool HandleVehicleUpdate(TClient& c, const std::string& Packet);
 };
 
 struct BufferView {

--- a/include/TServer.h
+++ b/include/TServer.h
@@ -43,8 +43,8 @@ private:
     static bool ShouldSpawn(TClient& c, const std::string& CarJson, int ID);
     static bool IsUnicycle(TClient& c, const std::string& CarJson);
     static void Apply(TClient& c, int VID, const std::string& pckt);
-    static bool HandlePosition(TClient& c, const std::string& Packet);
-    static bool HandleVehicleUpdate(TClient& c, const std::string& Packet);
+    static bool HandlePosition(TClient& c, const std::string& PacketStr);
+    static bool HandleVehicleUpdate(const std::string& PacketStr, const int playerID);
 };
 
 struct BufferView {

--- a/include/TServer.h
+++ b/include/TServer.h
@@ -43,7 +43,7 @@ private:
     static bool ShouldSpawn(TClient& c, const std::string& CarJson, int ID);
     static bool IsUnicycle(TClient& c, const std::string& CarJson);
     static void Apply(TClient& c, int VID, const std::string& pckt);
-    static void HandlePosition(TClient& c, const std::string& Packet);
+    static bool HandlePosition(TClient& c, const std::string& Packet);
 };
 
 struct BufferView {

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -18,6 +18,8 @@
 #include <boost/phoenix.hpp>
 #include <boost/spirit/include/qi.hpp>
 
+#include <boost/algorithm/string.hpp>
+
 static inline bool StringStartsWith(const std::string& What, const std::string& StartsWith) {
     return What.size() >= StartsWith.size() && What.substr(0, StartsWith.size()) == StartsWith;
 }
@@ -370,15 +372,15 @@ void TConsole::Command_Kick(const std::string&, const std::vector<std::string>& 
     bool Kicked = false;
     // TODO: this sucks, tolower is locale-dependent.
     auto NameCompare = [](std::string Name1, std::string Name2) -> bool {
-        std::for_each(Name1.begin(), Name1.end(), [](char& c) { c = char(std::tolower(char(c))); });
-        std::for_each(Name2.begin(), Name2.end(), [](char& c) { c = char(std::tolower(char(c))); });
-        return StringStartsWith(Name1, Name2) || StringStartsWith(Name2, Name1);
+        std::string Name1Lower = boost::algorithm::to_lower_copy(Name1);
+        std::string Name2Lower = boost::algorithm::to_lower_copy(Name2);
+        return StringStartsWith(Name1Lower, Name2Lower) || StringStartsWith(Name2Lower, Name1Lower);
     };
     mLuaEngine->Server().ForEachClient([&](std::weak_ptr<TClient> Client) -> bool {
         auto Locked = Client.lock();
         if (Locked) {
-            if (NameCompare(locked->GetName(), Name)) {
-                mLuaEngine->Network().ClientKick(*locked, Reason);
+            if (NameCompare(Locked->GetName(), Name)) {
+                mLuaEngine->Network().ClientKick(*Locked, Reason);
                 Kicked = true;
                 return false;
             }

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -374,8 +374,8 @@ void TConsole::Command_Kick(const std::string&, const std::vector<std::string>& 
         return StringStartsWith(Name1, Name2) || StringStartsWith(Name2, Name1);
     };
     mLuaEngine->Server().ForEachClient([&](std::weak_ptr<TClient> Client) -> bool {
-        if (!Client.expired()) {
-            auto locked = Client.lock();
+        auto Locked = Client.lock();
+        if (Locked) {
             if (NameCompare(locked->GetName(), Name)) {
                 mLuaEngine->Network().ClientKick(*locked, Reason);
                 Kicked = true;

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -282,8 +282,8 @@ void TConsole::Command_Debug(const std::string&, const std::vector<std::string>&
         Application::MalformedUdpPackets,
         Application::InvalidUdpPackets));
     Application::Console().WriteRaw(fmt::format(R"(    Clients:
-        Note: All data/second rates are an average across the total time since 
-              connection and do not necessarily reflect the *current* data rate 
+        Note: All data/second rates are an average across the total time since
+              connection and do not necessarily reflect the *current* data rate
               of that client.
 )"));
     mLuaEngine->Server().ForEachClient([&](std::weak_ptr<TClient> Client) -> bool {
@@ -653,6 +653,69 @@ void TConsole::Command_Status(const std::string&, const std::vector<std::string>
     Application::Console().WriteRaw(Status.str());
 }
 
+void TConsole::Autocomplete_Lua(const std::string& stub, std::vector<std::string>& suggestions) {
+    auto stateNames = mLuaEngine->GetLuaStateNames();
+
+    for (const auto& name : stateNames) {
+        if (name.find(stub) == 0) {
+            suggestions.push_back("lua " + name);
+        }
+    }
+}
+
+void TConsole::Autocomplete_Kick(const std::string& stub, std::vector<std::string>& suggestions) {
+    std::string stub_lower = boost::algorithm::to_lower_copy(stub);
+
+    auto LowercaseCompare = [](std::string Name1, std::string Name2) -> bool {
+        std::string NameLower = boost::algorithm::to_lower_copy(Name1);
+        return StringStartsWith(NameLower, Name2);
+    };
+
+    mLuaEngine->Server().ForEachClient([&](std::weak_ptr<TClient> Client) -> bool {
+        auto Locked = Client.lock();
+        if (Locked) {
+            if (LowercaseCompare(Locked->GetName(), stub_lower)) {
+                suggestions.push_back("kick " + Locked->GetName());
+            }
+        }
+        return true;
+    });
+
+}
+
+void TConsole::Autocomplete_Settings(const std::string& stub, std::vector<std::string>& suggestions) {
+    const std::string subcommands[] = { "help", "list", "set", "get" };
+
+    auto [command, args] = ParseCommand(stub);
+
+    std::string arg;
+    if (!args.empty()) arg = boost::algorithm::to_lower_copy(args.at(0));
+
+    auto LowercaseCompare = [](std::string Name1, std::string Name2) -> bool {
+        std::string NameLower = boost::algorithm::to_lower_copy(Name1);
+        return StringStartsWith(NameLower, Name2);
+    };
+
+    // suggest setting names
+    if (command == "set" || command == "get") {
+        for (const auto& [k, v] : Application::mSettings) {
+            std::string key = std::string(k);
+            if (LowercaseCompare(key, arg)) {
+                suggestions.push_back("settings " + command + " " + key);
+            }
+        }
+
+        return;
+    }
+
+    // suggest subcommands
+    for (const auto& cmd : subcommands) {
+        if (cmd.find(command) == 0) {
+            suggestions.push_back("settings " + cmd);
+        }
+    }
+}
+
 void TConsole::RunAsCommand(const std::string& cmd, bool IgnoreNotACommand) {
     auto FutureIsNonNil =
         [](const std::shared_ptr<TLuaResult>& Future) {
@@ -841,16 +904,15 @@ TConsole::TConsole() {
                     }
                 }
             } else { // if not lua
-                if (stub.find("lua") == 0) { // starts with "lua" means we should suggest state names
-                    std::string after_prefix = TrimString(stub.substr(3));
-                    auto stateNames = mLuaEngine->GetLuaStateNames();
-
-                    for (const auto& name : stateNames) {
-                        if (name.find(after_prefix) == 0) {
-                            suggestions.push_back("lua " + name);
-                        }
+                for (const auto& [cmd_name, autocomplete_fn] : mCommandAutocompleteMap) {
+                    if (stub.find(cmd_name) == 0) { // input starts with a full command (that has autocomplete)
+                        std::size_t cmd_len = cmd_name.length();
+                        std::string trimmed = TrimString(stub.substr(cmd_len));
+                        autocomplete_fn(trimmed, suggestions);
+                        break;
                     }
-                } else {
+                }
+                if (suggestions.empty()) {
                     for (const auto& [cmd_name, cmd_fn] : mCommandMap) {
                         if (cmd_name.find(stub) == 0) {
                             suggestions.push_back(cmd_name);

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -240,7 +240,8 @@ void TConsole::Command_Help(const std::string&, const std::vector<std::string>& 
     static constexpr const char* sHelpString = R"(
     Commands:
         help                    displays this help
-        exit                    shuts down the server
+        exit
+        quit                    shuts down the server
         kick <name> [reason]    kicks specified player with an optional reason
         list                    lists all players and info about them
         say <message>           sends the message to all players in chat
@@ -776,7 +777,7 @@ TConsole::TConsole() {
             } else {
                 if (!mLuaEngine) {
                     beammp_error("Attempted to run a command before Lua engine started. Please wait and try again.");
-                } else if (cmd == "exit") {
+                } else if (cmd == "exit"  || cmd == "quit") {
                     beammp_info("gracefully shutting down");
                     Application::GracefullyShutdown();
                 } else if (cmd == "say") {

--- a/src/TNetwork.cpp
+++ b/src/TNetwork.cpp
@@ -110,7 +110,7 @@ void TNetwork::UDPServerMain() {
                     Locked->UdpReceived += Data.size();
                     ++Locked->UdpPacketsReceived;
                     Data.erase(Data.begin() + 0, Data.begin() + 2);
-                    TServer::GlobalParser(Locked, std::move(Data), mPPSMonitor, *this);
+                    TServer::GlobalParser(Locked, std::move(Data), *this);
                 } catch (const std::exception&) {
                     ++Application::InvalidUdpPackets;
                 }
@@ -512,7 +512,7 @@ void TNetwork::TCPClient(const std::weak_ptr<TClient>& c) {
             Client->Disconnect("TCPRcv failed");
             break;
         }
-        TServer::GlobalParser(c, std::move(res), mPPSMonitor, *this);
+        TServer::GlobalParser(c, std::move(res), *this);
     }
 
     if (QueueSync.joinable())

--- a/src/TServer.cpp
+++ b/src/TServer.cpp
@@ -130,7 +130,7 @@ size_t TServer::ClientCount() const {
     return mClients.size();
 }
 
-void TServer::GlobalParser(const std::weak_ptr<TClient>& Client, std::vector<uint8_t>&& Packet, TPPSMonitor& PPSMonitor, TNetwork& Network) {
+void TServer::GlobalParser(const std::weak_ptr<TClient>& Client, std::vector<uint8_t>&& Packet, TNetwork& Network) {
     constexpr std::string_view ABG = "ABG:";
     if (Packet.size() >= ABG.size() && std::equal(Packet.begin(), Packet.begin() + ABG.size(), ABG.begin(), ABG.end())) {
         Packet.erase(Packet.begin(), Packet.begin() + ABG.size());


### PR DESCRIPTION
Included in this PR:
- add vehicle owner check to client packets
- update client pointer lock approach used in kick command
- add command 'quit' as alternative to 'exit'
- use boost for string lowercase comparison
- remove now unused PPSMonitor parameter
