### PR TITLE
Rc v3.2.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 - ADDED `debug` command, which shows info about connected clients & networking (for developers)
 - ADDED `Util.GenerateUUID()`, which generates an RFC4122 UUID (universally unique identifier)
 - ADDED `version` command, which shows version information
+- ADDED `onPlayerRequestMods` event, letting Lua disallow individual mods from being sent to clients
 - CHANGED `onShutdown` to be called before all players are kicked
 
 # v3.1.1

--- a/include/Client.h
+++ b/include/Client.h
@@ -10,6 +10,7 @@
 #include "BoostAliases.h"
 #include "Common.h"
 #include "Compat.h"
+#include "TResourceManager.h"
 #include "VehicleData.h"
 
 class TServer;
@@ -102,6 +103,8 @@ public:
     std::atomic_size_t TcpSent = 0;
 
     TimeType::time_point ConnectionTime {};
+
+    ModMap AllowedMods;
 
 private:
     void InsertVehicle(int ID, const std::string& Data);

--- a/include/Common.h
+++ b/include/Common.h
@@ -52,18 +52,18 @@ constexpr std::string_view StrAuthKey = "AuthKey";
 constexpr std::string_view StrLogChat = "LogChat";
 
 // Misc
-constexpr std::string_view StrSendErrors = "Misc.SendErrors";
-constexpr std::string_view StrSendErrorsMessageEnabled = "Misc.SendErrorsShowMessage";
-constexpr std::string_view StrHideUpdateMessages = "Misc.ImScaredOfUpdates";
-constexpr std::string_view StrIncludeSubdirectories = "Misc.IncludeSubdirectories";
+constexpr std::string_view StrSendErrors = "SendErrors";
+constexpr std::string_view StrSendErrorsMessageEnabled = "SendErrorsShowMessage";
+constexpr std::string_view StrHideUpdateMessages = "ImScaredOfUpdates";
+constexpr std::string_view StrIncludeSubdirectories = "IncludeSubdirectories";
 
 // HTTP
-constexpr std::string_view StrHTTPServerEnabled = "HTTP.HTTPServerEnabled";
-constexpr std::string_view StrHTTPServerUseSSL = "HTTP.UseSSL";
-constexpr std::string_view StrSSLKeyPath = "HTTP.SSLKeyPath";
-constexpr std::string_view StrSSLCertPath = "HTTP.SSLCertPath";
-constexpr std::string_view StrHTTPServerPort = "HTTP.HTTPServerPort";
-constexpr std::string_view StrHTTPServerIP = "HTTP.HTTPServerIP";
+constexpr std::string_view StrHTTPServerEnabled = "HTTPServerEnabled";
+constexpr std::string_view StrHTTPServerUseSSL = "UseSSL";
+constexpr std::string_view StrSSLKeyPath = "SSLKeyPath";
+constexpr std::string_view StrSSLCertPath = "SSLCertPath";
+constexpr std::string_view StrHTTPServerPort = "HTTPServerPort";
+constexpr std::string_view StrHTTPServerIP = "HTTPServerIP";
 
 // Unused
 constexpr std::string_view StrCustomIP = "Unused.CustomIP";

--- a/include/Common.h
+++ b/include/Common.h
@@ -55,6 +55,7 @@ constexpr std::string_view StrLogChat = "LogChat";
 constexpr std::string_view StrSendErrors = "Misc.SendErrors";
 constexpr std::string_view StrSendErrorsMessageEnabled = "Misc.SendErrorsShowMessage";
 constexpr std::string_view StrHideUpdateMessages = "Misc.ImScaredOfUpdates";
+constexpr std::string_view StrIncludeSubdirectories = "Misc.IncludeSubdirectories";
 
 // HTTP
 constexpr std::string_view StrHTTPServerEnabled = "HTTP.HTTPServerEnabled";
@@ -78,6 +79,9 @@ struct Version {
 
 template <typename T>
 using SparseArray = std::unordered_map<size_t, T>;
+
+template <typename K, typename V>
+using HashMap = std::unordered_map<K, V>;
 
 using boost::variant;
 using boost::container::flat_map;

--- a/include/TLuaEngine.h
+++ b/include/TLuaEngine.h
@@ -35,14 +35,15 @@ namespace fs = std::filesystem;
 /**
  * std::variant means, that TLuaArgTypes may be one of the Types listed as template args
  */
-using TLuaValue = std::variant<std::string, int, JsonString, bool, std::unordered_map<std::string, std::string>, float>;
+using TLuaValue = std::variant<std::string, int, JsonString, bool, std::unordered_map<std::string, std::string>, std::unordered_map<std::string, size_t>, float>;
 enum TLuaType {
     String = 0,
     Int = 1,
     Json = 2,
     Bool = 3,
     StringStringMap = 4,
-    Float = 5,
+    StringSizeTMap = 5,
+    Float = 6,
 };
 
 class TLuaPlugin;

--- a/include/TNetwork.h
+++ b/include/TNetwork.h
@@ -46,7 +46,7 @@ private:
     void Looper(const std::weak_ptr<TClient>& c);
     int OpenID();
     void OnDisconnect(const std::weak_ptr<TClient>& ClientPtr);
-    void Parse(TClient& c, const std::vector<uint8_t>& Packet);
+    void HandleResourcePackets(TClient& c, const std::vector<uint8_t>& Packet);
     void SendFile(TClient& c, const std::string& Name);
     static bool TCPSendRaw(TClient& C, ip::tcp::socket& socket, const uint8_t* Data, size_t Size);
     static void SplitLoad(TClient& c, size_t Sent, size_t Size, bool D, const std::string& Name);

--- a/include/TNetwork.h
+++ b/include/TNetwork.h
@@ -46,6 +46,7 @@ private:
     void Looper(const std::weak_ptr<TClient>& c);
     int OpenID();
     void OnDisconnect(const std::weak_ptr<TClient>& ClientPtr);
+    ModMap GetClientMods(TClient& Client);
     void HandleResourcePackets(TClient& c, const std::vector<uint8_t>& Packet);
     void SendFile(TClient& c, const std::string& Name);
     static bool TCPSendRaw(TClient& C, ip::tcp::socket& socket, const uint8_t* Data, size_t Size);

--- a/include/TResourceManager.h
+++ b/include/TResourceManager.h
@@ -1,21 +1,22 @@
 #pragma once
 
 #include "Common.h"
+#include <optional>
+
+using ModMap = HashMap<std::string, size_t>;
 
 class TResourceManager {
 public:
     TResourceManager();
 
-    [[nodiscard]] size_t MaxModSize() const { return mMaxModSize; }
-    [[nodiscard]] std::string FileList() const { return mFileList; }
-    [[nodiscard]] std::string TrimmedList() const { return mTrimmedList; }
-    [[nodiscard]] std::string FileSizes() const { return mFileSizes; }
-    [[nodiscard]] int ModsLoaded() const { return mModsLoaded; }
+    [[nodiscard]] size_t TotalModsSize() const { return mTotalModSize; }
+    [[nodiscard]] ModMap FileMap() const { return mMods; }
+    [[nodiscard]] static std::string FormatForBackend(const ModMap& mods);
+    [[nodiscard]] static std::string FormatForClient(const ModMap& mods);
+    [[nodiscard]] static std::optional<std::string> IsModValid(std::string& pathString, const ModMap& mods);
+    [[nodiscard]] int LoadedModCount() const { return mMods.size(); }
 
 private:
-    size_t mMaxModSize = 0;
-    std::string mFileSizes;
-    std::string mFileList;
-    std::string mTrimmedList;
-    int mModsLoaded = 0;
+    size_t mTotalModSize = 0; // size of all mods
+    ModMap mMods; // map of mod names
 };

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -35,6 +35,7 @@ Application::SettingsMap Application::mSettings = {
     { StrHTTPServerUseSSL, false },
     { StrHideUpdateMessages, false },
     { StrAuthKey, std::string("") },
+    { StrIncludeSubdirectories, false },
 };
 
 // global, yes, this is ugly, no, it cant be done another way

--- a/src/LuaAPI.cpp
+++ b/src/LuaAPI.cpp
@@ -298,6 +298,7 @@ void LuaAPI::MP::PrintRaw(sol::variadic_args Args) {
 }
 
 int LuaAPI::PanicHandler(lua_State* State) {
+    //FIXME: unsafe operation, can cause stack overflow
     beammp_lua_error("PANIC: " + sol::stack::get<std::string>(State, 1));
     return 0;
 }

--- a/src/LuaAPI.cpp
+++ b/src/LuaAPI.cpp
@@ -298,7 +298,7 @@ void LuaAPI::MP::PrintRaw(sol::variadic_args Args) {
 }
 
 int LuaAPI::PanicHandler(lua_State* State) {
-    //FIXME: unsafe operation, can cause stack overflow
+    // FIXME: unsafe operation, can cause stack overflow
     beammp_lua_error("PANIC: " + sol::stack::get<std::string>(State, 1));
     return 0;
 }

--- a/src/TConfig.cpp
+++ b/src/TConfig.cpp
@@ -87,6 +87,8 @@ void TConfig::FlushToFile() {
     SetComment(data["Misc"][StrSendErrors.data()].comments(), " You can turn on/off the SendErrors message you get on startup here");
     data["Misc"][StrSendErrorsMessageEnabled.data()] = Application::GetSettingBool(StrSendErrorsMessageEnabled.data());
     SetComment(data["Misc"][StrSendErrorsMessageEnabled.data()].comments(), " If SendErrors is `true`, the server will send helpful info about crashes and other issues back to the BeamMP developers. This info may include your config, who is on your server at the time of the error, and similar general information. This kind of data is vital in helping us diagnose and fix issues faster. This has no impact on server performance. You can opt-out of this system by setting this to `false`");
+    data["Misc"][StrIncludeSubdirectories.data()] = Application::GetSettingBool(StrIncludeSubdirectories.data());
+    SetComment(data["Misc"][StrIncludeSubdirectories.data()].comments(), " Whether or not to include subdirectories in General.ResourceFolder/Client when searching for `.zip`s");
     // HTTP
     data["HTTP"][StrSSLKeyPath.data()] = Application::GetSettingString(StrSSLKeyPath.data());
     data["HTTP"][StrSSLCertPath.data()] = Application::GetSettingString(StrSSLCertPath.data());

--- a/src/TConfig.cpp
+++ b/src/TConfig.cpp
@@ -160,6 +160,7 @@ void TConfig::ParseFromFile(std::string_view name) {
         TryReadValue(data, "Misc", StrSendErrors);
         TryReadValue(data, "Misc", StrHideUpdateMessages);
         TryReadValue(data, "Misc", StrSendErrorsMessageEnabled);
+        TryReadValue(data, "Misc", StrIncludeSubdirectories);
         // HTTP
         TryReadValue(data, "HTTP", StrSSLKeyPath);
         TryReadValue(data, "HTTP", StrSSLCertPath);

--- a/src/THeartbeatThread.cpp
+++ b/src/THeartbeatThread.cpp
@@ -145,9 +145,9 @@ std::string THeartbeatThread::GenerateCall() {
         << "&version=" << Application::ServerVersionString()
         << "&clientversion=" << std::to_string(Application::ClientMajorVersion()) + ".0" // FIXME: Wtf.
         << "&name=" << Application::GetSettingString(StrName)
-        << "&modlist=" << mResourceManager.TrimmedList()
-        << "&modstotalsize=" << mResourceManager.MaxModSize()
-        << "&modstotal=" << mResourceManager.ModsLoaded()
+        << "&modlist=" << TResourceManager::FormatForBackend(mResourceManager.FileMap())
+        << "&modstotalsize=" << mResourceManager.TotalModsSize()
+        << "&modstotal=" << mResourceManager.LoadedModCount()
         << "&playerslist=" << GetPlayers()
         << "&desc=" << Application::GetSettingString(StrDescription);
     return Ret.str();

--- a/src/TLuaEngine.cpp
+++ b/src/TLuaEngine.cpp
@@ -253,11 +253,15 @@ std::vector<std::string> TLuaEngine::StateThreadData::GetStateTableKeys(const st
         } else if (i == keys.size() - 1) {
             if (obj.get_type() == sol::type::table) {
                 for (const auto& [key, value] : obj.as<sol::table>()) {
-                    std::string s = key.as<std::string>();
-                    if (value.get_type() == sol::type::function) {
-                        s += "(";
+                    if (key.get_type() == sol::type::string) {
+                        std::string s = key.as<std::string>();
+
+                        if (value.get_type() == sol::type::function) {
+                            s += "(";
+                        }
+
+                        Result.push_back(s);
                     }
-                    Result.push_back(s);
                 }
             } else {
                 Result = { obj.as<std::string>() };

--- a/src/TLuaEngine.cpp
+++ b/src/TLuaEngine.cpp
@@ -1054,6 +1054,15 @@ void TLuaEngine::StateThreadData::operator()() {
                             LuaArgs.push_back(sol::make_object(StateView, Table));
                             break;
                         }
+                        case TLuaType::StringSizeTMap: {
+                            auto Map = std::get<std::unordered_map<std::string, size_t>>(Arg);
+                            auto Table = StateView.create_table();
+                            for (const auto& [k, v] : Map) {
+                                Table[k] = v;
+                            }
+                            LuaArgs.push_back(sol::make_object(StateView, Table));
+                            break;
+                        }
                         default:
                             beammp_error("Unknown argument type, passed as nil");
                             break;

--- a/src/TNetwork.cpp
+++ b/src/TNetwork.cpp
@@ -617,7 +617,7 @@ void TNetwork::SyncResources(TClient& c) {
 ModMap TNetwork::GetClientMods(TClient& Client) {
     auto AllMods = mResourceManager.FileMap();
 
-    auto Futures = LuaAPI::MP::Engine->TriggerEvent("onPlayerRequestMods", "", Client.GetName(), Client.GetRoles(), Client.IsGuest(), Client.GetIdentifiers(), AllMods);
+    auto Futures = LuaAPI::MP::Engine->TriggerEvent("onPlayerRequestMods", "", Client.GetName(), Client.GetRoles(), Client.IsGuest(), Client.GetIdentifiers(), Client.GetID(), AllMods);
     TLuaEngine::WaitForAll(Futures);
 
     ModMap AllowedMods = AllMods;

--- a/src/TResourceManager.cpp
+++ b/src/TResourceManager.cpp
@@ -70,7 +70,6 @@ TResourceManager::TResourceManager() {
             continue;
         if ((entry.is_regular_file() || entry.is_symlink()) && entry.path().extension() == ".zip") {
             auto relativePath = fs::relative(entry.path(), BasePath);
-            beammp_infof("mod entry: {}", relativePath.string());
 
             mMods[relativePath.string()] = entry.file_size();
             mTotalModSize += entry.file_size();

--- a/src/TResourceManager.cpp
+++ b/src/TResourceManager.cpp
@@ -5,31 +5,80 @@
 
 namespace fs = std::filesystem;
 
+std::string TResourceManager::FormatForBackend(const ModMap& mods) {
+    std::string monkey;
+    for (const auto& [name, size] : mods) {
+        monkey += fs::path(name).filename().string() + ';';
+    }
+    return monkey;
+}
+
+std::string TResourceManager::FormatForClient(const ModMap& mods) {
+    std::string monkey;
+    for (const auto& [name, size] : mods) {
+        monkey += '/' + name + ';';
+    }
+    for (const auto& [name, size] : mods) {
+        monkey += std::to_string(size) + ';';
+    }
+    return monkey;
+}
+
+/// @brief Sanitizes a requested mod string
+/// @param pathString Raw mod path string
+/// @param mods List of allowed mods for this client
+/// @return Error, if any
+std::optional<std::string> TResourceManager::IsModValid(std::string& pathString, const ModMap& mods) {
+    auto path = fs::path(pathString);
+    if (!path.has_filename()) {
+        beammp_warn("File " + pathString + " is not a file!");
+        return { "the requested file doesn't contain a valid filename" };
+    }
+
+    auto BasePath = fs::path(Application::GetSettingString(StrResourceFolder) + "/Client");
+
+    auto CombinedPath = fs::path(BasePath.string() + pathString).lexically_normal();
+
+    // beammp_infof("path: {}, base: {}, combined: {}", pathString, BasePath.string(), CombinedPath.string());
+
+    if (!std::filesystem::exists(CombinedPath)) {
+        beammp_warn("File " + pathString + " could not be accessed!");
+        return { "the requested file doesn't exist or couldn't be accessed" };
+    }
+
+    auto relative = fs::relative(CombinedPath, BasePath);
+
+    if (mods.count(relative.string()) == 0) {
+        beammp_warn("File " + pathString + " is disallowed for this player!");
+        return { "the requested file is disallowed for this player" };
+    }
+
+    pathString = CombinedPath.string();
+    return {};
+}
+
 TResourceManager::TResourceManager() {
     Application::SetSubsystemStatus("ResourceManager", Application::Status::Starting);
-    std::string Path = Application::GetSettingString(StrResourceFolder) + "/Client";
-    if (!fs::exists(Path))
-        fs::create_directories(Path);
-    for (const auto& entry : fs::directory_iterator(Path)) {
-        std::string File(entry.path().string());
-        if (auto pos = File.find(".zip"); pos != std::string::npos) {
-            if (File.length() - pos == 4) {
-                std::replace(File.begin(), File.end(), '\\', '/');
-                mFileList += File + ';';
-                if (auto i = File.find_last_of('/'); i != std::string::npos) {
-                    ++i;
-                    File = File.substr(i, pos - i);
-                }
-                mTrimmedList += "/" + fs::path(File).filename().string() + ';';
-                mFileSizes += std::to_string(size_t(fs::file_size(entry.path()))) + ';';
-                mMaxModSize += size_t(fs::file_size(entry.path()));
-                mModsLoaded++;
-            }
+    std::string BasePath = Application::GetSettingString(StrResourceFolder) + "/Client";
+    if (!fs::exists(BasePath))
+        fs::create_directories(BasePath);
+    std::vector<std::string> modNames;
+
+    auto iterator = fs::recursive_directory_iterator(BasePath, fs::directory_options::follow_directory_symlink | fs::directory_options::skip_permission_denied);
+    for (const auto& entry : iterator) {
+        if (iterator.depth() > 0 && !Application::GetSettingBool(StrIncludeSubdirectories))
+            continue;
+        if ((entry.is_regular_file() || entry.is_symlink()) && entry.path().extension() == ".zip") {
+            auto relativePath = fs::relative(entry.path(), BasePath);
+            beammp_infof("mod entry: {}", relativePath.string());
+
+            mMods[relativePath.string()] = entry.file_size();
+            mTotalModSize += entry.file_size();
         }
     }
 
-    if (mModsLoaded) {
-        beammp_info("Loaded " + std::to_string(mModsLoaded) + " Mods");
+    if (!mMods.empty()) {
+        beammp_infof("Loaded {} mod{}", mMods.size(), mMods.size() != 1 ? 's' : ' ');
     }
 
     Application::SetSubsystemStatus("ResourceManager", Application::Status::Good);


### PR DESCRIPTION
fix lua autocomplete crash when a table contains number keys

assign IDs to new players earlier in the connection process

add event 'onPlayerRequestMods', restructure modloading
