### PR TITLE
fix: Bad package name for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Ubuntu 22.04
 git
 libz-dev
 rapidjson-dev
-liblua5.3
+liblua5.3-dev
 libssl-dev
 libwebsocketpp-dev
 libcurl4-openssl-dev


### PR DESCRIPTION
The package name for liblua required to build is not correct. The correct name is [`liblua-5.3-dev`](https://packages.ubuntu.com/search?suite=all&searchon=names&keywords=liblua5.3)