### PR TITLE
Added Tags Feature to the BeamMP Server. 

### DIFF
--- a/include/Common.h
+++ b/include/Common.h
@@ -137,6 +137,8 @@ private:
     static inline Version mVersion { 3, 2, 0 };
 };
 
+void SplitString(std::string const& str, const char delim, std::vector<std::string>& out);
+
 std::string ThreadName(bool DebugModeOverride = false);
 void RegisterThread(const std::string& str);
 #define RegisterThreadAuto() RegisterThread(__func__)

--- a/include/Common.h
+++ b/include/Common.h
@@ -43,7 +43,7 @@ public:
     struct TSettings {
         std::string ServerName { "BeamMP Server" };
         std::string ServerDesc { "BeamMP Default Description" };
-        std::string ServerTags { "BeamMP,Server" };
+        std::string ServerTags { "Freeroam" };
         std::string Resource { "Resources" };
         std::string MapName { "/levels/gridmap_v2/info.json" };
         std::string Key {};

--- a/include/Common.h
+++ b/include/Common.h
@@ -43,6 +43,7 @@ public:
     struct TSettings {
         std::string ServerName { "BeamMP Server" };
         std::string ServerDesc { "BeamMP Default Description" };
+        std::string ServerTags { "BeamMP,Server" };
         std::string Resource { "Resources" };
         std::string MapName { "/levels/gridmap_v2/info.json" };
         std::string Key {};

--- a/include/TConfig.h
+++ b/include/TConfig.h
@@ -27,6 +27,7 @@ private:
     void TryReadValue(toml::value& Table, const std::string& Category, const std::string_view& Key, int& OutValue);
 
     void ParseOldFormat();
+    std::string TagsAsPrettyArray() const;
     bool IsDefault();
     bool mFailed { false };
     std::string mConfigFileName;

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -348,3 +348,14 @@ std::string GetPlatformAgnosticErrorString() {
     return "(no human-readable errors on this platform)";
 #endif
 }
+
+// TODO: add unit tests to SplitString
+void SplitString(const std::string& str, const char delim, std::vector<std::string>& out) {
+    size_t start;
+    size_t end = 0;
+
+    while ((start = str.find_first_not_of(delim, end)) != std::string::npos) {
+        end = str.find(delim, start);
+        out.push_back(str.substr(start, end - start));
+    }
+}

--- a/src/TConfig.cpp
+++ b/src/TConfig.cpp
@@ -15,6 +15,7 @@ static constexpr std::string_view StrMaxPlayers = "MaxPlayers";
 static constexpr std::string_view StrMap = "Map";
 static constexpr std::string_view StrName = "Name";
 static constexpr std::string_view StrDescription = "Description";
+static constexpr std::string_view StrTags = "Tags";
 static constexpr std::string_view StrResourceFolder = "ResourceFolder";
 static constexpr std::string_view StrAuthKey = "AuthKey";
 static constexpr std::string_view StrLogChat = "LogChat";
@@ -102,6 +103,8 @@ void TConfig::FlushToFile() {
     data["General"][StrPrivate.data()] = Application::Settings.Private;
     data["General"][StrPort.data()] = Application::Settings.Port;
     data["General"][StrName.data()] = Application::Settings.ServerName;
+    SetComment(data["General"][StrTags.data()].comments(), " Add custom identifying tags to your server to make it easier to find. Format should be TagA,TagB,TagC. Note the comma seperation.");
+    data["General"][StrTags.data()] = Application::Settings.ServerTags;
     data["General"][StrMaxCars.data()] = Application::Settings.MaxCars;
     data["General"][StrMaxPlayers.data()] = Application::Settings.MaxPlayers;
     data["General"][StrMap.data()] = Application::Settings.MapName;
@@ -129,7 +132,7 @@ void TConfig::FlushToFile() {
     std::stringstream Ss;
     Ss << "# This is the BeamMP-Server config file.\n"
           "# Help & Documentation: `https://wiki.beammp.com/en/home/server-maintenance`\n"
-          "# IMPORTANT: Fill in the AuthKey with the key you got from `https://beammp.com/k/dashboard` on the left under \"Keys\"\n"
+          "# IMPORTANT: Fill in the AuthKey with the key you got from `https://keymaster.beammp.com/` on the left under \"Keys\"\n"
        << data;
     auto File = std::fopen(mConfigFileName.c_str(), "w+");
     if (!File) {
@@ -189,6 +192,7 @@ void TConfig::ParseFromFile(std::string_view name) {
         TryReadValue(data, "General", StrMap, Application::Settings.MapName);
         TryReadValue(data, "General", StrName, Application::Settings.ServerName);
         TryReadValue(data, "General", StrDescription, Application::Settings.ServerDesc);
+        TryReadValue(data, "General", StrTags, Application::Settings.ServerTags);
         TryReadValue(data, "General", StrResourceFolder, Application::Settings.Resource);
         TryReadValue(data, "General", StrAuthKey, Application::Settings.Key);
         TryReadValue(data, "General", StrLogChat, Application::Settings.LogChat);
@@ -236,6 +240,7 @@ void TConfig::PrintDebug() {
     beammp_debug(std::string(StrMap) + ": \"" + Application::Settings.MapName + "\"");
     beammp_debug(std::string(StrName) + ": \"" + Application::Settings.ServerName + "\"");
     beammp_debug(std::string(StrDescription) + ": \"" + Application::Settings.ServerDesc + "\"");
+    beammp_debug(std::string(StrTags) + ": \"" + Application::Settings.ServerTags + "\"");
     beammp_debug(std::string(StrLogChat) + ": \"" + (Application::Settings.LogChat ? "true" : "false") + "\"");
     beammp_debug(std::string(StrResourceFolder) + ": \"" + Application::Settings.Resource + "\"");
     beammp_debug(std::string(StrSSLKeyPath) + ": \"" + Application::Settings.SSLKeyPath + "\"");

--- a/src/TConfig.cpp
+++ b/src/TConfig.cpp
@@ -214,7 +214,7 @@ void TConfig::PrintDebug() {
     beammp_debug(std::string(StrMap) + ": \"" + Application::Settings.MapName + "\"");
     beammp_debug(std::string(StrName) + ": \"" + Application::Settings.ServerName + "\"");
     beammp_debug(std::string(StrDescription) + ": \"" + Application::Settings.ServerDesc + "\"");
-    beammp_debug(std::string(StrTags) + ": \"" + Application::Settings.ServerTags + "\"");
+    beammp_debug(std::string(StrTags) + ": " + TagsAsPrettyArray());
     beammp_debug(std::string(StrLogChat) + ": \"" + (Application::Settings.LogChat ? "true" : "false") + "\"");
     beammp_debug(std::string(StrResourceFolder) + ": \"" + Application::Settings.Resource + "\"");
     // special!
@@ -273,4 +273,14 @@ void TConfig::ParseOldFormat() {
         }
         Str >> std::ws;
     }
+}
+std::string TConfig::TagsAsPrettyArray() const {
+    std::vector<std::string> TagsArray = {};
+    SplitString(Application::Settings.ServerTags, ',', TagsArray);
+    std::string Pretty = {};
+    for (size_t i = 0; i < TagsArray.size() - 1; ++i) {
+        Pretty += '\"' + TagsArray[i] + "\", ";
+    }
+    Pretty += '\"' + TagsArray.at(TagsArray.size()-1) + "\"";
+    return Pretty;
 }

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -52,17 +52,6 @@ TEST_CASE("TrimString") {
     CHECK(TrimString("") == "");
 }
 
-// TODO: add unit tests to SplitString
-static inline void SplitString(std::string const& str, const char delim, std::vector<std::string>& out) {
-    size_t start;
-    size_t end = 0;
-
-    while ((start = str.find_first_not_of(delim, end)) != std::string::npos) {
-        end = str.find(delim, start);
-        out.push_back(str.substr(start, end - start));
-    }
-}
-
 static std::string GetDate() {
     std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
     time_t tt = std::chrono::system_clock::to_time_t(now);

--- a/src/THeartbeatThread.cpp
+++ b/src/THeartbeatThread.cpp
@@ -129,6 +129,7 @@ std::string THeartbeatThread::GenerateCall() {
         << "&version=" << Application::ServerVersionString()
         << "&clientversion=" << std::to_string(Application::ClientMajorVersion()) + ".0" // FIXME: Wtf.
         << "&name=" << Application::Settings.ServerName
+        << "&tags=" << Application::Settings.ServerTags
         << "&modlist=" << mResourceManager.TrimmedList()
         << "&modstotalsize=" << mResourceManager.MaxModSize()
         << "&modstotal=" << mResourceManager.ModsLoaded()


### PR DESCRIPTION
This PR adds a tags functionality to the BeamMP server config and heartbeat.
The intended purpose of this is to enable better filtering on the server list based on keywords such as gamemode or roleplay.