### PR TITLE
Fix lua assertions crashing the server

### DIFF
--- a/include/TLuaEngine.h
+++ b/include/TLuaEngine.h
@@ -18,6 +18,9 @@
 #include <vector>
 
 #define SOL_ALL_SAFETIES_ON 1
+#define SOL_USER_C_ASSERT SOL_ON
+#define SOL_C_ASSERT(...) \
+    beammp_lua_errorf("SOL2 assertion failure: Assertion `{}` failed in {}:{}. This *should* be a fatal error, but BeamMP Server overrides it to not be fatal. This may cause the Lua Engine to crash, or cause other issues.", #__VA_ARGS__, __FILE__, __LINE__)
 #include <sol/sol.hpp>
 
 using TLuaStateId = std::string;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -89,7 +89,7 @@ int BeamMPServerMain(MainArguments Arguments) {
         Application::Console().WriteRaw("BeamMP-Server v" + Application::ServerVersionString());
         return 0;
     }
-
+    
     std::string ConfigPath = "ServerConfig.toml";
     if (Parser.FoundArgument({ "config" })) {
         auto MaybeConfigPath = Parser.GetValueOfArgument({ "config" });

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -89,7 +89,7 @@ int BeamMPServerMain(MainArguments Arguments) {
         Application::Console().WriteRaw("BeamMP-Server v" + Application::ServerVersionString());
         return 0;
     }
-    
+
     std::string ConfigPath = "ServerConfig.toml";
     if (Parser.FoundArgument({ "config" })) {
         auto MaybeConfigPath = Parser.GetValueOfArgument({ "config" });


### PR DESCRIPTION
The server would crash on a Lua plugin ASSERT() - this now instead prints an error. May still lead to weird behavior, but less weird than a crash.