### PR TITLE
Major refactor of Client and Server

### DIFF
--- a/include/Client.h
+++ b/include/Client.h
@@ -44,7 +44,6 @@ public:
     void SetIdentifier(const std::string& key, const std::string& value);
     std::string GetCarData(int Ident);
     std::string GetCarPositionRaw(int Ident);
-    void Disconnect(std::string_view Reason);
     bool IsDisconnected() const { return !TCPSocket->is_open(); }
     // locks
     void DeleteCar(int Ident);
@@ -75,7 +74,12 @@ public:
     Sync<std::queue<std::vector<uint8_t>>> MissedPacketsQueue;
     Sync<std::chrono::time_point<std::chrono::high_resolution_clock>> LastPingTime;
 
+    friend class TNetwork;
+
 private:
+    /// ONLY call after the client has been cleaned up, all cars deleted, etc.
+    void CloseSockets(std::string_view Reason);
+
     void InsertVehicle(int ID, const std::string& Data);
 
     TServer& mServer;

--- a/include/Client.h
+++ b/include/Client.h
@@ -30,11 +30,6 @@ class TClient final {
 public:
     using TSetOfVehicleData = std::vector<TVehicleData>;
 
-    struct TVehicleDataLockPair {
-        TSetOfVehicleData* VehicleData;
-        std::unique_lock<std::mutex> Lock;
-    };
-
     TClient(TServer& Server, ip::tcp::socket&& Socket);
     TClient(const TClient&) = delete;
     ~TClient();

--- a/include/Sync.h
+++ b/include/Sync.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <boost/thread/synchronized_value.hpp>
+
+/// This header provides convenience aliases for synchronization primitives.
+
+template<typename T>
+using Sync = boost::synchronized_value<T>;
+

--- a/include/TLuaEngine.h
+++ b/include/TLuaEngine.h
@@ -220,6 +220,8 @@ private:
         // Debug functions, slow
         std::queue<std::pair<TLuaChunk, std::shared_ptr<TLuaResult>>> Debug_GetStateExecuteQueue();
         std::vector<TLuaEngine::QueuedFunction> Debug_GetStateFunctionQueue();
+        
+        sol::table Lua_JsonDecode(const std::string& str);
 
     private:
         sol::table Lua_TriggerGlobalEvent(const std::string& EventName, sol::variadic_args EventArgs);
@@ -230,7 +232,6 @@ private:
         sol::table Lua_GetPlayerVehicles(int ID);
         std::pair<sol::table, std::string> Lua_GetPositionRaw(int PID, int VID);
         sol::table Lua_HttpCreateConnection(const std::string& host, uint16_t port);
-        sol::table Lua_JsonDecode(const std::string& str);
         int Lua_GetPlayerIDByName(const std::string& Name);
         sol::table Lua_FS_ListFiles(const std::string& Path);
         sol::table Lua_FS_ListDirectories(const std::string& Path);

--- a/include/TNetwork.h
+++ b/include/TNetwork.h
@@ -43,8 +43,9 @@ private:
     void OnConnect(const std::weak_ptr<TClient>& c);
     void TCPClient(const std::weak_ptr<TClient>& c);
     void Looper(const std::weak_ptr<TClient>& c);
-    int OpenID();
+    void OnDisconnect(const std::shared_ptr<TClient>& ClientPtr);
     void OnDisconnect(const std::weak_ptr<TClient>& ClientPtr);
+    void OnDisconnect(TClient& Client);
     void Parse(TClient& c, const std::vector<uint8_t>& Packet);
     void SendFile(TClient& c, const std::string& Name);
     static bool TCPSendRaw(TClient& C, ip::tcp::socket& socket, const uint8_t* Data, size_t Size);

--- a/include/TNetwork.h
+++ b/include/TNetwork.h
@@ -19,6 +19,9 @@ public:
     std::shared_ptr<TClient> CreateClient(ip::tcp::socket&& TCPSock);
     std::vector<uint8_t> TCPRcv(TClient& c);
     void ClientKick(TClient& c, const std::string& R);
+    void Disconnect(const std::shared_ptr<TClient>& ClientPtr);
+    void Disconnect(const std::weak_ptr<TClient>& ClientPtr);
+    void Disconnect(TClient& Client);
     [[nodiscard]] bool SyncClient(const std::weak_ptr<TClient>& c);
     void Identify(TConnection&& client);
     std::shared_ptr<TClient> Authentication(TConnection&& ClientConnection);
@@ -43,14 +46,11 @@ private:
     void OnConnect(const std::weak_ptr<TClient>& c);
     void TCPClient(const std::weak_ptr<TClient>& c);
     void Looper(const std::weak_ptr<TClient>& c);
-    void OnDisconnect(const std::shared_ptr<TClient>& ClientPtr);
-    void OnDisconnect(const std::weak_ptr<TClient>& ClientPtr);
-    void OnDisconnect(TClient& Client);
     void Parse(TClient& c, const std::vector<uint8_t>& Packet);
     void SendFile(TClient& c, const std::string& Name);
-    static bool TCPSendRaw(TClient& C, ip::tcp::socket& socket, const uint8_t* Data, size_t Size);
-    static void SplitLoad(TClient& c, size_t Sent, size_t Size, bool D, const std::string& Name);
-    static const uint8_t* SendSplit(TClient& c, ip::tcp::socket& Socket, const uint8_t* DataPtr, size_t Size);
+    bool TCPSendRaw(TClient& C, ip::tcp::socket& socket, const uint8_t* Data, size_t Size);
+    void SplitLoad(TClient& c, size_t Sent, size_t Size, bool D, const std::string& Name);
+    const uint8_t* SendSplit(TClient& c, ip::tcp::socket& Socket, const uint8_t* DataPtr, size_t Size);
 };
 
 std::string HashPassword(const std::string& str);

--- a/include/TNetwork.h
+++ b/include/TNetwork.h
@@ -44,8 +44,8 @@ private:
     std::vector<uint8_t> UDPRcvFromClient(ip::udp::endpoint& ClientEndpoint);
     void HandleDownload(TConnection&& TCPSock);
     void OnConnect(const std::weak_ptr<TClient>& c);
-    void TCPClient(const std::weak_ptr<TClient>& c);
-    void Looper(const std::weak_ptr<TClient>& c);
+    void TCPClient(const std::shared_ptr<TClient>& c);
+    void Looper(const std::shared_ptr<TClient>& c);
     void Parse(TClient& c, const std::vector<uint8_t>& Packet);
     void SendFile(TClient& c, const std::string& Name);
     bool TCPSendRaw(TClient& C, ip::tcp::socket& socket, const uint8_t* Data, size_t Size);

--- a/include/TServer.h
+++ b/include/TServer.h
@@ -27,7 +27,7 @@ public:
     void ForEachClient(const std::function<bool(const std::shared_ptr<TClient>&)> Fn);
     size_t ClientCount() const;
 
-    void GlobalParser(const std::weak_ptr<TClient>& Client, std::vector<uint8_t>&& Packet, TPPSMonitor& PPSMonitor, TNetwork& Network);
+    void GlobalParser(const std::shared_ptr<TClient>& Client, std::vector<uint8_t>&& Packet, TPPSMonitor& PPSMonitor, TNetwork& Network);
     static void HandleEvent(TClient& c, const std::string& Data);
     RWMutex& GetClientMutex() const { return mClientsMutex; }
 

--- a/include/TServer.h
+++ b/include/TServer.h
@@ -22,13 +22,18 @@ public:
 
     void InsertClient(const std::shared_ptr<TClient>& Ptr);
     void RemoveClient(const std::weak_ptr<TClient>&);
+    void RemoveClient(TClient&);
     // in Fn, return true to continue, return false to break
-    void ForEachClient(const std::function<bool(std::weak_ptr<TClient>)>& Fn);
+    [[deprecated("Use ForEachClient instead")]] void ForEachClientWeak(const std::function<bool(std::weak_ptr<TClient>)>& Fn);
+    void ForEachClient(const std::function<bool(const std::shared_ptr<TClient>&)> Fn);
     size_t ClientCount() const;
 
     void GlobalParser(const std::weak_ptr<TClient>& Client, std::vector<uint8_t>&& Packet, TPPSMonitor& PPSMonitor, TNetwork& Network);
     static void HandleEvent(TClient& c, const std::string& Data);
     RWMutex& GetClientMutex() const { return mClientsMutex; }
+
+    // thread-safe ID lookup & claim
+    void ClaimFreeIDFor(TClient& Client);
 
     const TScopedTimer UptimeTimer;
 

--- a/include/TServer.h
+++ b/include/TServer.h
@@ -24,7 +24,6 @@ public:
     void RemoveClient(const std::weak_ptr<TClient>&);
     void RemoveClient(TClient&);
     // in Fn, return true to continue, return false to break
-    [[deprecated("Use ForEachClient instead")]] void ForEachClientWeak(const std::function<bool(std::weak_ptr<TClient>)>& Fn);
     void ForEachClient(const std::function<bool(const std::shared_ptr<TClient>&)> Fn);
     size_t ClientCount() const;
 

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -144,8 +144,6 @@ std::optional<std::shared_ptr<TClient>> GetClient(TServer& Server, int ID) {
             MaybeClient = Client;
             return false;
         }
-        } else {
-            beammp_debugf("Found an expired client while looking for id {}", ID);
         return true;
     });
     return MaybeClient;

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -51,17 +51,25 @@ std::string TClient::GetCarPositionRaw(int Ident) {
     }
 }
 
-void TClient::Disconnect(std::string_view Reason) {
+void TClient::CloseSockets(std::string_view Reason) {
     auto LockedSocket = TCPSocket.synchronize();
     beammp_debugf("Disconnecting client {} for reason: {}", int(ID), Reason);
     boost::system::error_code ec;
     LockedSocket->shutdown(socket_base::shutdown_both, ec);
     if (ec) {
-        beammp_debugf("Failed to shutdown client socket: {}", ec.message());
+        beammp_debugf("Failed to shutdown client socket of client {}: {}", ID.get(), ec.message());
     }
     LockedSocket->close(ec);
     if (ec) {
-        beammp_debugf("Failed to close client socket: {}", ec.message());
+        beammp_debugf("Failed to close client socket of client {}: {}", ID.get(), ec.message());
+    }
+    DownSocket->shutdown(socket_base::shutdown_both, ec);
+    if (ec) {
+        beammp_debugf("Failed to shutdown client download socket of client {}: {}", ID.get(), ec.message());
+    }
+    DownSocket->close(ec);
+    if (ec) {
+        beammp_debugf("Failed to close client download socket of client {}: {}", ID.get(), ec.message());
     }
 }
 

--- a/src/LuaAPI.cpp
+++ b/src/LuaAPI.cpp
@@ -127,7 +127,7 @@ static inline std::pair<bool, std::string> InternalTriggerClientEvent(int Player
         auto c = MaybeClient.value();
         if (!LuaAPI::MP::Engine->Network().Respond(*c, StringToVector(Packet), true)) {
             beammp_lua_errorf("Respond failed, dropping client {}", PlayerID);
-            LuaAPI::MP::Engine->Network().ClientKick(*c, "Disconnected after failing to receive packets");
+            LuaAPI::MP::Engine->Network().Disconnect(*c);
             return { false, "Respond failed, dropping client" };
         }
         return { true, "" };
@@ -169,7 +169,8 @@ std::pair<bool, std::string> LuaAPI::MP::SendChatMessage(int ID, const std::stri
             LogChatMessage("<Server> (to \"" + c->Name.get() + "\")", -1, Message);
             if (!Engine->Network().Respond(*c, StringToVector(Packet), true)) {
                 beammp_errorf("Failed to send chat message back to sender (id {}) - did the sender disconnect?", ID);
-                // TODO: should we return an error here?
+                beammp_infof("Disconnecting client {} for failure to receive a chat message (TCP disconnect)", c->Name.get());
+                Engine->Network().Disconnect(c);
             }
             Result.first = true;
         } else {

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -266,15 +266,12 @@ void TConsole::Command_Kick(const std::string&, const std::vector<std::string>& 
         std::for_each(Name2.begin(), Name2.end(), [](char& c) { c = char(std::tolower(char(c))); });
         return StringStartsWith(Name1, Name2) || StringStartsWith(Name2, Name1);
     };
-    mLuaEngine->Server().ForEachClientWeak([&](std::weak_ptr<TClient> Client) -> bool {
-        if (!Client.expired()) {
-            auto locked = Client.lock();
-            if (NameCompare(locked->Name.get(), Name)) {
-                mLuaEngine->Network().ClientKick(*locked, Reason);
+    mLuaEngine->Server().ForEachClient([&](const std::shared_ptr<TClient>& Client) -> bool {
+            if (NameCompare(Client->Name.get(), Name)) {
+                mLuaEngine->Network().ClientKick(*Client, Reason);
                 Kicked = true;
                 return false;
             }
-        }
         return true;
     });
     if (!Kicked) {
@@ -364,13 +361,10 @@ void TConsole::Command_List(const std::string&, const std::vector<std::string>& 
     } else {
         std::stringstream ss;
         ss << std::left << std::setw(25) << "Name" << std::setw(6) << "ID" << std::setw(6) << "Cars" << std::endl;
-        mLuaEngine->Server().ForEachClientWeak([&](std::weak_ptr<TClient> Client) -> bool {
-            if (!Client.expired()) {
-                auto locked = Client.lock();
-                ss << std::left << std::setw(25) << locked->Name.get()
-                   << std::setw(6) << locked->ID.get()
-                   << std::setw(6) << locked->GetCarCount() << "\n";
-            }
+        mLuaEngine->Server().ForEachClient([&](const std::shared_ptr<TClient>& Client) -> bool {
+            ss << std::left << std::setw(25) << Client->Name.get()
+               << std::setw(6) << Client->ID.get()
+               << std::setw(6) << Client->GetCarCount() << "\n";
             return true;
         });
         auto Str = ss.str();

--- a/src/THeartbeatThread.cpp
+++ b/src/THeartbeatThread.cpp
@@ -153,11 +153,8 @@ THeartbeatThread::THeartbeatThread(TResourceManager& ResourceManager, TServer& S
 }
 std::string THeartbeatThread::GetPlayers() {
     std::string Return;
-    mServer.ForEachClient([&](const std::weak_ptr<TClient>& ClientPtr) -> bool {
-        ReadLock Lock(mServer.GetClientMutex());
-        if (!ClientPtr.expired()) {
-            Return += ClientPtr.lock()->GetName() + ";";
-        }
+    mServer.ForEachClient([&](const std::shared_ptr<TClient>& ClientPtr) -> bool {
+        Return += ClientPtr->Name.get() + ";";
         return true;
     });
     return Return;

--- a/src/TLuaEngine.cpp
+++ b/src/TLuaEngine.cpp
@@ -497,11 +497,8 @@ sol::table TLuaEngine::StateThreadData::Lua_GetPlayerIdentifiers(int ID) {
 
 sol::table TLuaEngine::StateThreadData::Lua_GetPlayers() {
     sol::table Result = mStateView.create_table();
-    mEngine->Server().ForEachClientWeak([&](std::weak_ptr<TClient> Client) -> bool {
-        if (!Client.expired()) {
-            auto locked = Client.lock();
-            Result[locked->ID.get()] = locked->Name.get();
-        }
+    mEngine->Server().ForEachClient([&](const std::shared_ptr<TClient>& Client) -> bool {
+        Result[Client->ID.get()] = Client->Name.get();
         return true;
     });
     return Result;
@@ -509,13 +506,10 @@ sol::table TLuaEngine::StateThreadData::Lua_GetPlayers() {
 
 int TLuaEngine::StateThreadData::Lua_GetPlayerIDByName(const std::string& Name) {
     int Id = -1;
-    mEngine->mServer->ForEachClientWeak([&Id, &Name](std::weak_ptr<TClient> Client) -> bool {
-        if (!Client.expired()) {
-            auto locked = Client.lock();
-            if (locked->Name.get() == Name) {
-                Id = locked->ID.get();
-                return false;
-            }
+    mEngine->mServer->ForEachClient([&Id, &Name](const std::shared_ptr<TClient>& Client) -> bool {
+        if (Client->Name.get() == Name) {
+            Id = Client->ID.get();
+            return false;
         }
         return true;
     });

--- a/src/TPPSMonitor.cpp
+++ b/src/TPPSMonitor.cpp
@@ -33,7 +33,7 @@ void TPPSMonitor::operator()() {
             Application::SetPPS("-");
             continue;
         }
-        mServer.ForEachClient([&](const std::weak_ptr<TClient>& ClientPtr) -> bool {
+        mServer.ForEachClientWeak([&](const std::weak_ptr<TClient>& ClientPtr) -> bool {
             std::shared_ptr<TClient> c;
             {
                 ReadLock Lock(mServer.GetClientMutex());
@@ -48,7 +48,7 @@ void TPPSMonitor::operator()() {
             }
             // kick on "no ping"
             if (c->SecondsSinceLastPing() > (20 * 60)) {
-                beammp_debug("client " + std::string("(") + std::to_string(c->GetID()) + ")" + c->GetName() + " timing out: " + std::to_string(c->SecondsSinceLastPing()) + ", pps: " + Application::PPS());
+                beammp_debug("client " + std::string("(") + std::to_string(c->ID.get()) + ")" + c->Name.get() + " timing out: " + std::to_string(c->SecondsSinceLastPing()) + ", pps: " + Application::PPS());
                 TimedOutClients.push_back(c);
             }
 

--- a/src/TPPSMonitor.cpp
+++ b/src/TPPSMonitor.cpp
@@ -33,15 +33,7 @@ void TPPSMonitor::operator()() {
             Application::SetPPS("-");
             continue;
         }
-        mServer.ForEachClientWeak([&](const std::weak_ptr<TClient>& ClientPtr) -> bool {
-            std::shared_ptr<TClient> c;
-            {
-                ReadLock Lock(mServer.GetClientMutex());
-                if (!ClientPtr.expired()) {
-                    c = ClientPtr.lock();
-                } else
-                    return true;
-            }
+        mServer.ForEachClient([&](const std::shared_ptr<TClient>& c) -> bool {
             if (c->GetCarCount() > 0) {
                 C++;
                 V += c->GetCarCount();

--- a/src/TServer.cpp
+++ b/src/TServer.cpp
@@ -171,19 +171,6 @@ void TServer::ForEachClient(const std::function<bool(const std::shared_ptr<TClie
     }
 }
 
-void TServer::ForEachClientWeak(const std::function<bool(std::weak_ptr<TClient>)>& Fn) {
-    decltype(mClients) Clients;
-    {
-        ReadLock lock(mClientsMutex);
-        Clients = mClients;
-    }
-    for (auto& Client : Clients) {
-        if (!Fn(Client)) {
-            break;
-        }
-    }
-}
-
 size_t TServer::ClientCount() const {
     ReadLock Lock(mClientsMutex);
     return mClients.size();
@@ -224,7 +211,7 @@ void TServer::GlobalParser(const std::weak_ptr<TClient>& Client, std::vector<uin
     case 'p':
         if (!Network.Respond(*LockedClient, StringToVector("p"), false)) {
             // failed to send
-            LockedClient->Disconnect("Failed to send ping");
+            Disconnect(LockedClient);
         } else {
             Network.UpdatePlayer(*LockedClient);
         }


### PR DESCRIPTION
this refactor includes changes to TClient:

- all member fields are now public, but protected with Sync (an alias for boost::synchronized_value
- removed all (now) obsolete getters and setters

changes to TServer and TNetwork:

- thread-safe ID generation, previously it was possible for there to be ID duplicates. this is now solved by moving id generation and assignment into the same mutex locked context.
- replaced ForEachClientWeak with ForEachClient, getting rid of the weak_ptr shit in most places
- implemented a bunch of new functions for getting rid of more weak_ptr everywhere