### PR TITLE
Add Lua execution profiler `Util.DebugExecutionTime()`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ set(PRJ_HEADERS
     include/TServer.h
     include/VehicleData.h
     include/Env.h
+    include/Profiling.h
 )
 # add all source files (.cpp) to this, except the one with main()
 set(PRJ_SOURCES
@@ -72,6 +73,7 @@ set(PRJ_SOURCES
     src/TServer.cpp
     src/VehicleData.cpp
     src/Env.cpp
+    src/Profiling.cpp
 )
 
 find_package(Lua REQUIRED)

--- a/include/Profiling.h
+++ b/include/Profiling.h
@@ -45,6 +45,9 @@ struct UnitProfileCollection {
     /// Returns the number of elements the moving average is calculated over.
     size_t measurement_count(const std::string& unit);
 
+    /// Returns the averages for all stored units.
+    std::unordered_map<std::string, double> all_average_durations();
+
 private:
     boost::synchronized_value<std::unordered_map<std::string, UnitExecutionTime>> m_map;
 };

--- a/include/Profiling.h
+++ b/include/Profiling.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <boost/circular_buffer.hpp>
 #include <boost/thread/synchronized_value.hpp>
 #include <chrono>
 #include <cstddef>
 #include <limits>
+#include <unordered_map>
 
 namespace prof {
 
@@ -38,9 +38,10 @@ struct UnitExecutionTime {
     Stats stats() const;
 
     /// Returns the number of elements the moving average is calculated over.
-    size_t measurement_count() const { return m_total_calls; }
+    size_t measurement_count() const;
 
 private:
+    std::mutex m_mtx {};
     size_t m_total_calls {};
     double m_sum {};
     // sum of measurements squared (for running stdev)

--- a/include/Profiling.h
+++ b/include/Profiling.h
@@ -23,7 +23,6 @@ struct Stats {
     double min;
     double max;
     size_t n;
-    size_t total_calls;
 };
 
 /// Calculates and stores the moving average over K samples of execution time data

--- a/include/Profiling.h
+++ b/include/Profiling.h
@@ -22,6 +22,7 @@ struct Stats {
     double min;
     double max;
     size_t n;
+    size_t total_calls;
 };
 
 /// Calculates and stores the moving average over K samples of execution time data
@@ -41,6 +42,7 @@ struct UnitExecutionTime {
 
 private:
     boost::synchronized_value<boost::circular_buffer<Duration>> m_measurements;
+    size_t m_total_calls {};
 };
 
 /// Holds profiles for multiple units by name. Threadsafe.

--- a/include/Profiling.h
+++ b/include/Profiling.h
@@ -21,6 +21,7 @@ struct Stats {
     double stddev;
     double min;
     double max;
+    size_t n;
 };
 
 /// Calculates and stores the moving average over K samples of execution time data

--- a/include/Profiling.h
+++ b/include/Profiling.h
@@ -41,7 +41,7 @@ struct UnitExecutionTime {
     size_t measurement_count() const;
 
 private:
-    std::mutex m_mtx {};
+    mutable std::mutex m_mtx {};
     size_t m_total_calls {};
     double m_sum {};
     // sum of measurements squared (for running stdev)

--- a/include/Profiling.h
+++ b/include/Profiling.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <boost/circular_buffer.hpp>
+#include <boost/thread/synchronized_value.hpp>
+#include <chrono>
+#include <cstddef>
+
+namespace prof {
+
+using Duration = std::chrono::duration<double, std::milli>;
+using TimePoint = std::chrono::high_resolution_clock::time_point;
+
+/// Returns the current time.
+TimePoint now();
+
+/// Returns a sub-millisecond resolution duration between start and end.
+Duration duration(const TimePoint& start, const TimePoint& end);
+
+/// Calculates and stores the moving average over K samples of execution time data
+/// for some single unit of code. Threadsafe.
+struct UnitExecutionTime {
+    UnitExecutionTime();
+
+    /// Adds a sample to the collection, overriding the oldest sample if needed.
+    void add_sample(const Duration& dur);
+
+    /// Calculates the average duration over the `measurement_count()` measurements.
+    Duration average_duration() const;
+
+    /// Returns the number of elements the moving average is calculated over.
+    size_t measurement_count();
+
+private:
+    boost::synchronized_value<boost::circular_buffer<Duration>> m_measurements;
+};
+
+/// Holds profiles for multiple units by name. Threadsafe.
+struct UnitProfileCollection {
+    /// Adds a sample to the collection, overriding the oldest sample if needed.
+    void add_sample(const std::string& unit, const Duration& duration);
+
+    /// Calculates the average duration over the `measurement_count()` measurements.
+    Duration average_duration(const std::string& unit);
+
+    /// Returns the number of elements the moving average is calculated over.
+    size_t measurement_count(const std::string& unit);
+
+private:
+    boost::synchronized_value<std::unordered_map<std::string, UnitExecutionTime>> m_map;
+};
+
+}

--- a/include/Profiling.h
+++ b/include/Profiling.h
@@ -16,6 +16,13 @@ TimePoint now();
 /// Returns a sub-millisecond resolution duration between start and end.
 Duration duration(const TimePoint& start, const TimePoint& end);
 
+struct Stats {
+    double mean;
+    double stddev;
+    double min;
+    double max;
+};
+
 /// Calculates and stores the moving average over K samples of execution time data
 /// for some single unit of code. Threadsafe.
 struct UnitExecutionTime {
@@ -24,8 +31,9 @@ struct UnitExecutionTime {
     /// Adds a sample to the collection, overriding the oldest sample if needed.
     void add_sample(const Duration& dur);
 
-    /// Calculates the average duration over the `measurement_count()` measurements.
-    Duration average_duration() const;
+    /// Calculates the mean duration over the `measurement_count()` measurements,
+    /// as well as the standard deviation.
+    Stats stats() const;
 
     /// Returns the number of elements the moving average is calculated over.
     size_t measurement_count();
@@ -39,14 +47,15 @@ struct UnitProfileCollection {
     /// Adds a sample to the collection, overriding the oldest sample if needed.
     void add_sample(const std::string& unit, const Duration& duration);
 
-    /// Calculates the average duration over the `measurement_count()` measurements.
-    Duration average_duration(const std::string& unit);
+    /// Calculates the mean duration over the `measurement_count()` measurements,
+    /// as well as the standard deviation.
+    Stats stats(const std::string& unit);
 
     /// Returns the number of elements the moving average is calculated over.
     size_t measurement_count(const std::string& unit);
 
-    /// Returns the averages for all stored units.
-    std::unordered_map<std::string, double> all_average_durations();
+    /// Returns the stats for all stored units.
+    std::unordered_map<std::string, Stats> all_stats();
 
 private:
     boost::synchronized_value<std::unordered_map<std::string, UnitExecutionTime>> m_map;

--- a/include/Profiling.h
+++ b/include/Profiling.h
@@ -4,6 +4,7 @@
 #include <boost/thread/synchronized_value.hpp>
 #include <chrono>
 #include <cstddef>
+#include <limits>
 
 namespace prof {
 
@@ -18,7 +19,7 @@ Duration duration(const TimePoint& start, const TimePoint& end);
 
 struct Stats {
     double mean;
-    double stddev;
+    double stdev;
     double min;
     double max;
     size_t n;
@@ -38,11 +39,15 @@ struct UnitExecutionTime {
     Stats stats() const;
 
     /// Returns the number of elements the moving average is calculated over.
-    size_t measurement_count();
+    size_t measurement_count() const { return m_total_calls; }
 
 private:
-    boost::synchronized_value<boost::circular_buffer<Duration>> m_measurements;
     size_t m_total_calls {};
+    double m_sum {};
+    // sum of measurements squared (for running stdev)
+    double m_measurement_sqr_sum {};
+    double m_min { std::numeric_limits<double>::max() };
+    double m_max { std::numeric_limits<double>::min() };
 };
 
 /// Holds profiles for multiple units by name. Threadsafe.

--- a/include/TLuaEngine.h
+++ b/include/TLuaEngine.h
@@ -256,6 +256,7 @@ private:
         sol::table Lua_FS_ListDirectories(const std::string& Path);
 
         prof::UnitProfileCollection mProfile {};
+        std::unordered_map<std::string, prof::TimePoint> mProfileStarts;
 
         std::string mName;
         TLuaStateId mStateId;

--- a/include/TLuaEngine.h
+++ b/include/TLuaEngine.h
@@ -18,9 +18,11 @@
 
 #pragma once
 
+#include "Profiling.h"
 #include "TNetwork.h"
 #include "TServer.h"
 #include <any>
+#include <chrono>
 #include <condition_variable>
 #include <filesystem>
 #include <initializer_list>
@@ -252,6 +254,8 @@ private:
         int Lua_GetPlayerIDByName(const std::string& Name);
         sol::table Lua_FS_ListFiles(const std::string& Path);
         sol::table Lua_FS_ListDirectories(const std::string& Path);
+
+        prof::UnitProfileCollection mProfile {};
 
         std::string mName;
         TLuaStateId mStateId;

--- a/src/Profiling.cpp
+++ b/src/Profiling.cpp
@@ -36,6 +36,15 @@ void prof::UnitExecutionTime::add_sample(const Duration& dur) {
 }
 
 prof::UnitExecutionTime::UnitExecutionTime()
-    : m_measurements(boost::circular_buffer<Duration>(16)) {
+    : m_measurements(boost::circular_buffer<Duration>(100)) {
+}
+
+std::unordered_map<std::string, double> prof::UnitProfileCollection::all_average_durations() {
+    auto map = m_map.synchronize();
+    std::unordered_map<std::string, double> result {};
+    for (const auto& [name, time] : *map) {
+        result[name] = time.average_duration().count();
+    }
+    return result;
 }
 

--- a/src/Profiling.cpp
+++ b/src/Profiling.cpp
@@ -52,11 +52,13 @@ prof::Stats prof::UnitExecutionTime::stats() const {
         result.stddev += std::pow(measurement.count() - result.mean, 2);
     }
     result.stddev = std::sqrt(result.stddev / double(measurements->size()));
+    result.total_calls = m_total_calls;
     return result;
 }
 
 void prof::UnitExecutionTime::add_sample(const Duration& dur) {
     m_measurements->push_back(dur);
+    ++m_total_calls;
 }
 
 prof::UnitExecutionTime::UnitExecutionTime()

--- a/src/Profiling.cpp
+++ b/src/Profiling.cpp
@@ -30,6 +30,7 @@ prof::Stats prof::UnitExecutionTime::stats() const {
     if (measurements->size() == 0) {
         return result;
     }
+    result.n = measurements->size();
     result.max = std::numeric_limits<double>::min();
     result.min = std::numeric_limits<double>::max();
     Duration sum {};

--- a/src/Profiling.cpp
+++ b/src/Profiling.cpp
@@ -1,0 +1,41 @@
+#include "Profiling.h"
+
+prof::Duration prof::duration(const TimePoint& start, const TimePoint& end) {
+    return end - start;
+}
+prof::TimePoint prof::now() {
+    return std::chrono::high_resolution_clock::now();
+}
+prof::Duration prof::UnitProfileCollection::average_duration(const std::string& unit) {
+    return m_map->operator[](unit).average_duration();
+}
+
+size_t prof::UnitProfileCollection::measurement_count(const std::string& unit) {
+    return m_map->operator[](unit).measurement_count();
+}
+
+void prof::UnitProfileCollection::add_sample(const std::string& unit, const Duration& duration) {
+    m_map->operator[](unit).add_sample(duration);
+}
+
+size_t prof::UnitExecutionTime::measurement_count() {
+    return m_measurements->size();
+}
+
+prof::Duration prof::UnitExecutionTime::average_duration() const {
+    auto measurements = m_measurements.synchronize();
+    Duration sum {};
+    for (const auto& measurement : *measurements) {
+        sum += measurement;
+    }
+    return sum / measurements->size();
+}
+
+void prof::UnitExecutionTime::add_sample(const Duration& dur) {
+    m_measurements->push_back(dur);
+}
+
+prof::UnitExecutionTime::UnitExecutionTime()
+    : m_measurements(boost::circular_buffer<Duration>(16)) {
+}
+

--- a/src/Profiling.cpp
+++ b/src/Profiling.cpp
@@ -20,6 +20,7 @@ void prof::UnitProfileCollection::add_sample(const std::string& unit, const Dura
 }
 
 prof::Stats prof::UnitExecutionTime::stats() const {
+    std::unique_lock lock(m_mtx);
     Stats result {};
     // calculate sum
     result.n = m_total_calls;
@@ -33,6 +34,7 @@ prof::Stats prof::UnitExecutionTime::stats() const {
 }
 
 void prof::UnitExecutionTime::add_sample(const Duration& dur) {
+    std::unique_lock lock(m_mtx);
     m_sum += dur.count();
     m_measurement_sqr_sum += dur.count() * dur.count();
     m_min = std::min(dur.count(), m_min);
@@ -51,3 +53,8 @@ std::unordered_map<std::string, prof::Stats> prof::UnitProfileCollection::all_st
     }
     return result;
 }
+size_t prof::UnitExecutionTime::measurement_count() const {
+    std::unique_lock lock(m_mtx);
+    return m_total_calls;
+}
+

--- a/src/TLuaEngine.cpp
+++ b/src/TLuaEngine.cpp
@@ -852,9 +852,13 @@ TLuaEngine::StateThreadData::StateThreadData(const std::string& Name, TLuaStateI
     UtilTable.set_function("DebugExecutionTime", [this]() -> sol::table {
         sol::state_view StateView(mState);
         sol::table Result = StateView.create_table();
-        auto durs = mProfile.all_average_durations();
-        for (const auto& [name, dur] : durs) {
-            Result[name] = dur;
+        auto stats = mProfile.all_stats();
+        for (const auto& [name, stat] : stats) {
+            Result[name] = StateView.create_table();
+            Result[name]["mean"] = stat.mean;
+            Result[name]["stddev"] = stat.stddev;
+            Result[name]["min"] = stat.min;
+            Result[name]["max"] = stat.max;
         }
         return Result;
     });

--- a/src/TLuaEngine.cpp
+++ b/src/TLuaEngine.cpp
@@ -860,7 +860,6 @@ TLuaEngine::StateThreadData::StateThreadData(const std::string& Name, TLuaStateI
             Result[name]["min"] = stat.min;
             Result[name]["max"] = stat.max;
             Result[name]["n"] = stat.n;
-            Result[name]["total_calls"] = stat.total_calls;
         }
         return Result;
     });

--- a/src/TLuaEngine.cpp
+++ b/src/TLuaEngine.cpp
@@ -859,8 +859,19 @@ TLuaEngine::StateThreadData::StateThreadData(const std::string& Name, TLuaStateI
             Result[name]["stddev"] = stat.stddev;
             Result[name]["min"] = stat.min;
             Result[name]["max"] = stat.max;
+            Result[name]["n"] = stat.n;
         }
         return Result;
+    });
+    UtilTable.set_function("DebugStartProfile", [this](const std::string& name) {
+        mProfileStarts[name] = prof::now();
+    });
+    UtilTable.set_function("DebugStopProfile", [this](const std::string& name) {
+        if (!mProfileStarts.contains(name)) {
+            beammp_lua_errorf("DebugStopProfile('{}') failed, because a profile for '{}' wasn't started", name, name);
+            return;
+        }
+        mProfile.add_sample(name, prof::duration(mProfileStarts.at(name), prof::now()));
     });
 
     auto HttpTable = StateView.create_named_table("Http");

--- a/src/TLuaEngine.cpp
+++ b/src/TLuaEngine.cpp
@@ -860,6 +860,7 @@ TLuaEngine::StateThreadData::StateThreadData(const std::string& Name, TLuaStateI
             Result[name]["min"] = stat.min;
             Result[name]["max"] = stat.max;
             Result[name]["n"] = stat.n;
+            Result[name]["total_calls"] = stat.total_calls;
         }
         return Result;
     });

--- a/src/TLuaEngine.cpp
+++ b/src/TLuaEngine.cpp
@@ -856,7 +856,7 @@ TLuaEngine::StateThreadData::StateThreadData(const std::string& Name, TLuaStateI
         for (const auto& [name, stat] : stats) {
             Result[name] = StateView.create_table();
             Result[name]["mean"] = stat.mean;
-            Result[name]["stddev"] = stat.stddev;
+            Result[name]["stdev"] = stat.stdev;
             Result[name]["min"] = stat.min;
             Result[name]["max"] = stat.max;
             Result[name]["n"] = stat.n;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -178,17 +178,6 @@ int BeamMPServerMain(MainArguments Arguments) {
         Http::Server::THttpServerInstance HttpServerInstance {};
     }
 
-    prof::UnitExecutionTime t {};
-    for (size_t i = 0; i < 10'000'000; ++i) {
-        t.add_sample(std::chrono::seconds(1));
-        t.add_sample(std::chrono::seconds(2));
-        t.add_sample(std::chrono::seconds(3));
-    }
-    auto stats = t.stats();
-    beammp_errorf("mean: {}, stdev: {}, min: {}, max: {}, n: {}", stats.mean, stats.stdev, stats.min, stats.max, stats.n);
-
-    exit(69);
-
     Application::SetSubsystemStatus("Main", Application::Status::Good);
     RegisterThread("Main(Waiting)");
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,7 +20,6 @@
 #include "Common.h"
 #include "Http.h"
 #include "LuaAPI.h"
-#include "Profiling.h"
 #include "SignalHandling.h"
 #include "TConfig.h"
 #include "THeartbeatThread.h"
@@ -31,7 +30,6 @@
 #include "TResourceManager.h"
 #include "TServer.h"
 
-#include <chrono>
 #include <iostream>
 #include <thread>
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,7 @@
 #include "Common.h"
 #include "Http.h"
 #include "LuaAPI.h"
+#include "Profiling.h"
 #include "SignalHandling.h"
 #include "TConfig.h"
 #include "THeartbeatThread.h"
@@ -30,6 +31,7 @@
 #include "TResourceManager.h"
 #include "TServer.h"
 
+#include <chrono>
 #include <iostream>
 #include <thread>
 
@@ -124,7 +126,7 @@ int BeamMPServerMain(MainArguments Arguments) {
             }
         }
     }
-    
+
     TConfig Config(ConfigPath);
 
     if (Config.Failed()) {
@@ -175,6 +177,17 @@ int BeamMPServerMain(MainArguments Arguments) {
     if (Application::Settings.HTTPServerEnabled) {
         Http::Server::THttpServerInstance HttpServerInstance {};
     }
+
+    prof::UnitExecutionTime t {};
+    for (size_t i = 0; i < 10'000'000; ++i) {
+        t.add_sample(std::chrono::seconds(1));
+        t.add_sample(std::chrono::seconds(2));
+        t.add_sample(std::chrono::seconds(3));
+    }
+    auto stats = t.stats();
+    beammp_errorf("mean: {}, stdev: {}, min: {}, max: {}, n: {}", stats.mean, stats.stdev, stats.min, stats.max, stats.n);
+
+    exit(69);
 
     Application::SetSubsystemStatus("Main", Application::Status::Good);
     RegisterThread("Main(Waiting)");

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,7 +6,6 @@
     "boost-spirit",
     "boost-uuid",
     "boost-variant",
-    "boost-circular-buffer",
     "cpp-httplib",
     "doctest",
     "fmt",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,6 +6,7 @@
     "boost-spirit",
     "boost-uuid",
     "boost-variant",
+    "boost-circular-buffer",
     "cpp-httplib",
     "doctest",
     "fmt",


### PR DESCRIPTION
Adds `Util.DebugExecutionTime()`, which returns a table of `function_name: milliseconds`, in which each function's execution time is averaged over all time.

You can call this function like so:
```lua
-- event to print the debug times
MP.RegisterEvent("printStuff", "printStuff")
-- prints the execution time of all event handlers
function printStuff()
	print(Util.DebugExecutionTime())
end
-- run every 5 seconds (or 10, or 60, whatever makes sense for you
MP.CreateEventTimer("printStuff", 5000)
```

Pretty print function:
```lua
function printDebugExecutionTime()
    local stats = Util.DebugExecutionTime()
    local pretty = "DebugExecutionTime:\n"
    local longest = 0
    for name, t in pairs(stats) do
        if #name > longest then
            longest = #name
        end
    end
    for name, t in pairs(stats) do
        pretty = pretty .. string.format("%" .. longest + 1 .. "s: %12f +/- %12f (min: %12f, max: %12f) (called %d time(s))\n", name, t.mean, t.stdev, t.min, t.max, t.n)
    end
    print(pretty)
end
```

`Util.DebugExecutionTime()` returns a table, where each key is an event handler function  name, and each value is a table consisting of `mean` (simple average), `stddev` (standard deviation aka mean of the variance), `min` and `max`, all in milliseconds, as well as `n` as the number of samples taken.