### PR TITLE
Fix Lua assert error when adding values to tables (e.g. in event arguments)

### DIFF
--- a/include/Common.h
+++ b/include/Common.h
@@ -150,7 +150,7 @@ private:
     static inline std::mutex mShutdownHandlersMutex {};
     static inline std::deque<TShutdownHandler> mShutdownHandlers {};
 
-    static inline Version mVersion { 3, 4, 0 };
+    static inline Version mVersion { 3, 4, 1 };
 };
 
 void SplitString(std::string const& str, const char delim, std::vector<std::string>& out);


### PR DESCRIPTION
When adding elements to a table, the .add() function does not behave as expected in various cases, making it really shit and difficult to use. Instead, we keep our own index and just add one by one. It works, and it's easy to understand.

This may lead to indices which are nil, i.e. non-fully-sequential tables, but I can't be asked to worry about it because that shouldn't be an issue when we use .set() everywhere.