### PR TITLE
Fix #326 Arch Compile Issue "copy_n is not a member of 'std';"

### DIFF
--- a/include/Common.h
+++ b/include/Common.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <atomic>
 #include <cstring>


### PR DESCRIPTION
added ```#include <algorithm>``` to Common.h, needed for "copy_n"