### PR TITLE
Add IPv6 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ set(PRJ_LIBRARIES
     commandline_static
     toml11::toml11
     rapidjson
-    sol2
+    sol2::sol2
     httplib::httplib
     libzip::zip
     OpenSSL::SSL OpenSSL::Crypto

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ set(PRJ_LIBRARIES
     commandline_static
     toml11::toml11
     rapidjson
-    sol2::sol2
+    sol2
     httplib::httplib
     libzip::zip
     OpenSSL::SSL OpenSSL::Crypto

--- a/include/Client.h
+++ b/include/Client.h
@@ -88,7 +88,7 @@ public:
     void ClearCars();
     [[nodiscard]] int GetID() const { return mID; }
     [[nodiscard]] int GetUnicycleID() const { return mUnicycleID; }
-    [[nodiscard]] bool IsConnected() const { return mIsConnected; }
+    [[nodiscard]] bool IsUDPConnected() const { return mIsUDPConnected; }
     [[nodiscard]] bool IsSynced() const { return mIsSynced; }
     [[nodiscard]] bool IsSyncing() const { return mIsSyncing; }
     [[nodiscard]] bool IsGuest() const { return mIsGuest; }
@@ -100,7 +100,7 @@ public:
     [[nodiscard]] const std::queue<std::vector<uint8_t>>& MissedPacketQueue() const { return mPacketsSync; }
     [[nodiscard]] size_t MissedPacketQueueSize() const { return mPacketsSync.size(); }
     [[nodiscard]] std::mutex& MissedPacketQueueMutex() const { return mMissedPacketsMutex; }
-    void SetIsConnected(bool NewIsConnected) { mIsConnected = NewIsConnected; }
+    void SetIsUDPConnected(bool NewIsConnected) { mIsUDPConnected = NewIsConnected; }
     [[nodiscard]] TServer& Server() const;
     void UpdatePingTime();
     int SecondsSinceLastPing();
@@ -109,7 +109,7 @@ private:
     void InsertVehicle(int ID, const std::string& Data);
 
     TServer& mServer;
-    bool mIsConnected = false;
+    bool mIsUDPConnected = false;
     bool mIsSynced = false;
     bool mIsSyncing = false;
     mutable std::mutex mMissedPacketsMutex;

--- a/src/LuaAPI.cpp
+++ b/src/LuaAPI.cpp
@@ -298,7 +298,7 @@ void LuaAPI::MP::Sleep(size_t Ms) {
 bool LuaAPI::MP::IsPlayerConnected(int ID) {
     auto MaybeClient = GetClient(Engine->Server(), ID);
     if (MaybeClient && !MaybeClient.value().expired()) {
-        return MaybeClient.value().lock()->IsConnected();
+        return MaybeClient.value().lock()->IsUDPConnected();
     } else {
         return false;
     }

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -543,7 +543,7 @@ void TConsole::Command_Status(const std::string&, const std::vector<std::string>
         if (!Client.expired()) {
             auto Locked = Client.lock();
             CarCount += Locked->GetCarCount();
-            ConnectedCount += Locked->IsConnected() ? 1 : 0;
+            ConnectedCount += Locked->IsUDPConnected() ? 1 : 0;
             GuestCount += Locked->IsGuest() ? 1 : 0;
             SyncedCount += Locked->IsSynced() ? 1 : 0;
             SyncingCount += Locked->IsSyncing() ? 1 : 0;

--- a/src/TNetwork.cpp
+++ b/src/TNetwork.cpp
@@ -176,7 +176,7 @@ void TNetwork::TCPServerMain() {
     }
 #if defined(BEAMMP_FREEBSD)
     beammp_warnf("WARNING: On FreeBSD, for IPv4 to work, you must run `sysctl net.inet6.ip6.v6only=0`!");
-    beammp_debugf("This is due to an annoying detail in the *BSDs: In the name of security, unsetting the IPV6_V6ONLY option does not work by default (but does not fail???), as it allows IPv4 mapped IPv6 like ::ffff:127.0.0.1, which they deem a security issue.");
+    beammp_debugf("This is due to an annoying detail in the *BSDs: In the name of security, unsetting the IPV6_V6ONLY option does not work by default (but does not fail???), as it allows IPv4 mapped IPv6 like ::ffff:127.0.0.1, which they deem a security issue. For more information, see RFC 2553, section 3.7.");
 #endif
     socket_base::linger LingerOpt {};
     LingerOpt.enabled(false);

--- a/src/TNetwork.cpp
+++ b/src/TNetwork.cpp
@@ -174,6 +174,10 @@ void TNetwork::TCPServerMain() {
     if (ec) {
         beammp_warnf("Failed to unset IP_V6ONLY on TCP, only IPv6 will work: {}", ec.message());
     }
+#if defined(BEAMMP_FREEBSD)
+    beammp_warnf("WARNING: On FreeBSD, for IPv4 to work, you must run `sysctl net.inet6.ip6.v6only=0`!");
+    beammp_debugf("This is due to an annoying detail in the *BSDs: In the name of security, unsetting the IPV6_V6ONLY option does not work by default (but does not fail???), as it allows IPv4 mapped IPv6 like ::ffff:127.0.0.1, which they deem a security issue.");
+#endif
     socket_base::linger LingerOpt {};
     LingerOpt.enabled(false);
     Listener.set_option(LingerOpt, ec);


### PR DESCRIPTION
Adds IPv6 support.

FreeBSD users beware: From this point forward, you will have to set `sysctl net.inet6.ip6.v6only=0` so that the BeamMP-Server continues to work. The server also prints this information. 