### PR TITLE
Add post event(s)

### DIFF
--- a/src/TNetwork.cpp
+++ b/src/TNetwork.cpp
@@ -437,21 +437,20 @@ std::shared_ptr<TClient> TNetwork::Authentication(TConnection&& RawConnection) {
         ClientKick(*Client, Reason);
     }
 
-    auto PostFutures = LuaAPI::MP::Engine->TriggerEvent("postPlayerAuth", "", Allowed, Client->GetName(), Client->GetRoles(), Client->IsGuest(), Client->GetIdentifiers());
-    // the post event is not cancellable so we dont wait for it
-    LuaAPI::MP::Engine->ReportErrors(PostFutures);
 
     if (!Allowed) {
         return {};
-    }
-
-    if (mServer.ClientCount() < size_t(Application::Settings.getAsInt(Settings::Key::General_MaxPlayers))) {
+    } else if (mServer.ClientCount() < size_t(Application::Settings.getAsInt(Settings::Key::General_MaxPlayers))) {
         beammp_info("Identification success");
         mServer.InsertClient(Client);
         TCPClient(Client);
     } else {
         ClientKick(*Client, "Server full!");
     }
+
+    auto PostFutures = LuaAPI::MP::Engine->TriggerEvent("postPlayerAuth", "", Allowed, Client->GetName(), Client->GetRoles(), Client->IsGuest(), Client->GetIdentifiers());
+    // the post event is not cancellable so we dont wait for it
+    LuaAPI::MP::Engine->ReportErrors(PostFutures);
 
     return Client;
 }

--- a/src/TNetwork.cpp
+++ b/src/TNetwork.cpp
@@ -431,15 +431,17 @@ std::shared_ptr<TClient> TNetwork::Authentication(TConnection&& RawConnection) {
         Allowed = false;
     }
 
+    if (NotAllowed) {
+        ClientKick(*Client, "you are not allowed on the server!");
+    } else if (NotAllowedWithReason) {
+        ClientKick(*Client, Reason);
+    }
+
     auto PostFutures = LuaAPI::MP::Engine->TriggerEvent("postPlayerAuth", "", Allowed, Client->GetName(), Client->GetRoles(), Client->IsGuest(), Client->GetIdentifiers());
     // the post event is not cancellable so we dont wait for it
     LuaAPI::MP::Engine->ReportErrors(PostFutures);
 
-    if (NotAllowed) {
-        ClientKick(*Client, "you are not allowed on the server!");
-        return {};
-    } else if (NotAllowedWithReason) {
-        ClientKick(*Client, Reason);
+    if (!Allowed) {
         return {};
     }
 

--- a/src/TNetwork.cpp
+++ b/src/TNetwork.cpp
@@ -423,6 +423,18 @@ std::shared_ptr<TClient> TNetwork::Authentication(TConnection&& RawConnection) {
         Reason = "No guests are allowed on this server! To join, sign up at: forum.beammp.com.";
     }
 
+    bool Allowed = true;
+    if (NotAllowed) {
+        Allowed = false;
+    }
+    if (NotAllowedWithReason) {
+        Allowed = false;
+    }
+
+    auto PostFutures = LuaAPI::MP::Engine->TriggerEvent("postPlayerAuth", "", Allowed, Client->GetName(), Client->GetRoles(), Client->IsGuest(), Client->GetIdentifiers());
+    // the post event is not cancellable so we dont wait for it
+    LuaAPI::MP::Engine->ReportErrors(PostFutures);
+
     if (NotAllowed) {
         ClientKick(*Client, "you are not allowed on the server!");
         return {};


### PR DESCRIPTION
Adds `post*` events which are triggered after the respective `on*` event has completed and the results have been sent.

They have the same arguments as the `on*` function, with the exception that another argument is added in the beginning which contains whether the `on*` variant was cancelled.

Added these for all cancellable events.