### PR TITLE
Add Lua function to get a player's role

### DIFF
--- a/include/TLuaEngine.h
+++ b/include/TLuaEngine.h
@@ -263,7 +263,7 @@ private:
         sol::table Lua_TriggerGlobalEvent(const std::string& EventName, sol::variadic_args EventArgs);
         sol::table Lua_TriggerLocalEvent(const std::string& EventName, sol::variadic_args EventArgs);
         sol::table Lua_GetPlayerIdentifiers(int ID);
-        std::string Lua_GetPlayerRole(int ID);
+        std::variant<std::string, sol::nil_t> Lua_GetPlayerRole(int ID);
         sol::table Lua_GetPlayers();
         std::string Lua_GetPlayerName(int ID);
         sol::table Lua_GetPlayerVehicles(int ID);

--- a/include/TLuaEngine.h
+++ b/include/TLuaEngine.h
@@ -263,6 +263,7 @@ private:
         sol::table Lua_TriggerGlobalEvent(const std::string& EventName, sol::variadic_args EventArgs);
         sol::table Lua_TriggerLocalEvent(const std::string& EventName, sol::variadic_args EventArgs);
         sol::table Lua_GetPlayerIdentifiers(int ID);
+        std::string Lua_GetPlayerRole(int ID);
         sol::table Lua_GetPlayers();
         std::string Lua_GetPlayerName(int ID);
         sol::table Lua_GetPlayerVehicles(int ID);

--- a/src/TLuaEngine.cpp
+++ b/src/TLuaEngine.cpp
@@ -597,10 +597,11 @@ sol::table TLuaEngine::StateThreadData::Lua_GetPlayerIdentifiers(int ID) {
 
 std::string TLuaEngine::StateThreadData::Lua_GetPlayerRole(int ID) {
     auto MaybeClient = GetClient(mEngine->Server(), ID);
-    if (MaybeClient && !MaybeClient.value().expired())
+    if (MaybeClient) {
         return MaybeClient.value().lock()->GetRoles();
-    else
+    } else {
         return "";
+    }
 }
 
 

--- a/src/TLuaEngine.cpp
+++ b/src/TLuaEngine.cpp
@@ -595,6 +595,15 @@ sol::table TLuaEngine::StateThreadData::Lua_GetPlayerIdentifiers(int ID) {
     }
 }
 
+std::string TLuaEngine::StateThreadData::Lua_GetPlayerRole(int ID) {
+    auto MaybeClient = GetClient(mEngine->Server(), ID);
+    if (MaybeClient && !MaybeClient.value().expired())
+        return MaybeClient.value().lock()->GetRoles();
+    else
+        return "";
+}
+
+
 sol::table TLuaEngine::StateThreadData::Lua_GetPlayers() {
     sol::table Result = mStateView.create_table();
     mEngine->Server().ForEachClient([&](std::weak_ptr<TClient> Client) -> bool {
@@ -882,6 +891,9 @@ TLuaEngine::StateThreadData::StateThreadData(const std::string& Name, TLuaStateI
     });
     MPTable.set_function("GetPlayerIdentifiers", [&](int ID) -> sol::table {
         return Lua_GetPlayerIdentifiers(ID);
+    });
+    MPTable.set_function("GetPlayerRole", [&](int ID) -> std::string {
+        return Lua_GetPlayerRole(ID);
     });
     MPTable.set_function("Sleep", &LuaAPI::MP::Sleep);
     //  const std::string& EventName, size_t IntervalMS, int strategy

--- a/src/TLuaEngine.cpp
+++ b/src/TLuaEngine.cpp
@@ -595,12 +595,12 @@ sol::table TLuaEngine::StateThreadData::Lua_GetPlayerIdentifiers(int ID) {
     }
 }
 
-std::string TLuaEngine::StateThreadData::Lua_GetPlayerRole(int ID) {
+std::variant<std::string, sol::nil_t> TLuaEngine::StateThreadData::Lua_GetPlayerRole(int ID) {
     auto MaybeClient = GetClient(mEngine->Server(), ID);
     if (MaybeClient) {
         return MaybeClient.value().lock()->GetRoles();
     } else {
-        return "";
+        return sol::nil;
     }
 }
 
@@ -893,7 +893,7 @@ TLuaEngine::StateThreadData::StateThreadData(const std::string& Name, TLuaStateI
     MPTable.set_function("GetPlayerIdentifiers", [&](int ID) -> sol::table {
         return Lua_GetPlayerIdentifiers(ID);
     });
-    MPTable.set_function("GetPlayerRole", [&](int ID) -> std::string {
+    MPTable.set_function("GetPlayerRole", [&](int ID) -> std::variant<std::string, sol::nil_t> {
         return Lua_GetPlayerRole(ID);
     });
     MPTable.set_function("Sleep", &LuaAPI::MP::Sleep);


### PR DESCRIPTION
Adds `MP.GetPlayerRole(player_id)` to the Lua API to get a player's role ("USER", "EA", "MDEV", "STAFF", "ET") by their player id.
Currently you can only get someone's role in onPlayerAuth from the parameters and in onVehicleSpawned and onVehicleEdited from the packet data, but not in onPlayerJoin for example without storing it. 