### PR TITLE
Make modlist an empty array by default instead of null

### DIFF
--- a/include/TResourceManager.h
+++ b/include/TResourceManager.h
@@ -43,5 +43,5 @@ private:
     int mModsLoaded = 0;
 
     std::mutex mModsMutex;
-    nlohmann::json mMods;
+    nlohmann::json mMods = nlohmann::json::array();
 };


### PR DESCRIPTION
Related launcher PR: https://github.com/BeamMP/BeamMP-Launcher/pull/136