### PR TITLE
Allow for empty icon param in MP.SendNotification

### DIFF
--- a/src/LuaAPI.cpp
+++ b/src/LuaAPI.cpp
@@ -207,7 +207,7 @@ std::pair<bool, std::string> LuaAPI::MP::SendChatMessage(int ID, const std::stri
 
 std::pair<bool, std::string> LuaAPI::MP::SendNotification(int ID, const std::string& Message, const std::string& Icon, const std::string& Category) {
     std::pair<bool, std::string> Result;
-    std::string Packet = "N" + Category + ":" + Icon + ":" + Message;
+    std::string Packet = "n" + Category + ":" + Icon + ":" + Message;
     if (ID == -1) {
         Engine->Network().SendToAll(nullptr, StringToVector(Packet), true, true);
         Result.first = true;

--- a/src/TLuaEngine.cpp
+++ b/src/TLuaEngine.cpp
@@ -880,12 +880,14 @@ TLuaEngine::StateThreadData::StateThreadData(const std::string& Name, TLuaStateI
     });
     MPTable.set_function("SendChatMessage", &LuaAPI::MP::SendChatMessage);
     MPTable.set_function("SendNotification", [&](sol::variadic_args Args) {
-        if (Args.size() == 3) {
+        if (Args.size() == 2) {
+            LuaAPI::MP::SendNotification(Args.get<int>(0), Args.get<std::string>(1), "", Args.get<std::string>(1));
+        } else if (Args.size() == 3) {
             LuaAPI::MP::SendNotification(Args.get<int>(0), Args.get<std::string>(1), Args.get<std::string>(2), Args.get<std::string>(1));
         } else if (Args.size() == 4) {
             LuaAPI::MP::SendNotification(Args.get<int>(0), Args.get<std::string>(1), Args.get<std::string>(2), Args.get<std::string>(3));
         } else {
-            beammp_lua_error("SendNotification expects 2 or 3 arguments.");
+            beammp_lua_error("SendNotification expects 2, 3 or 4 arguments.");
         }
     });
     MPTable.set_function("GetPlayers", [&]() -> sol::table {

--- a/src/TServer.cpp
+++ b/src/TServer.cpp
@@ -253,7 +253,6 @@ void TServer::GlobalParser(const std::weak_ptr<TClient>& Client, std::vector<uin
         HandleEvent(*LockedClient, StringPacket);
         return;
     case 'N':
-        beammp_trace("got 'N' packet (" + std::to_string(Packet.size()) + ")");
         Network.SendToAll(LockedClient.get(), Packet, false, true);
         return;
     case 'Z': // position packet


### PR DESCRIPTION
This PR allows you to call MP.SendNotification with only a player ID and a message, removing the requirement for an icon.