### PR TITLE
Fix build failure with Boost >= v1.87.0

### DIFF
--- a/src/TNetwork.cpp
+++ b/src/TNetwork.cpp
@@ -86,7 +86,7 @@ TNetwork::TNetwork(TServer& Server, TPPSMonitor& PPSMonitor, TResourceManager& R
 void TNetwork::UDPServerMain() {
     RegisterThread("UDPServer");
     // listen on all ipv6 addresses
-    ip::udp::endpoint UdpListenEndpoint(ip::address::from_string("::"), Application::Settings.getAsInt(Settings::Key::General_Port));
+    ip::udp::endpoint UdpListenEndpoint(ip::make_address("::"), Application::Settings.getAsInt(Settings::Key::General_Port));
     boost::system::error_code ec;
     mUDPSock.open(UdpListenEndpoint.protocol(), ec);
     if (ec) {
@@ -172,7 +172,7 @@ void TNetwork::TCPServerMain() {
 
     // listen on all ipv6 addresses
     auto port = uint16_t(Application::Settings.getAsInt(Settings::Key::General_Port));
-    ip::tcp::endpoint ListenEp(ip::address::from_string("::"), port);
+    ip::tcp::endpoint ListenEp(ip::make_address("::"), port);
     beammp_infof("Listening on 0.0.0.0:{0} and [::]:{0}", port);
     ip::tcp::socket Listener(mServer.IoCtx());
     boost::system::error_code ec;


### PR DESCRIPTION
Closes #401

Replace deprecated `ip::address::from_string` with `ip::make_address` to avoid build errors with Boost versions >= 1.87.0

---

By creating this pull request, I understand that code that is AI generated or otherwise automatically generated may be rejected without further discussion.
I declare that I fully understand all code I pushed into this PR, and wrote all this code myself and own the rights to this code.
