### PR TITLE
Add ENV for missing settings

### DIFF
--- a/src/TConfig.cpp
+++ b/src/TConfig.cpp
@@ -62,7 +62,9 @@ static constexpr std::string_view StrPassword = "Password";
 
 // Misc
 static constexpr std::string_view StrHideUpdateMessages = "ImScaredOfUpdates";
+static constexpr std::string_view EnvStrHideUpdateMessages = "BEAMMP_HIDE_UPDATE_MESSAGES";
 static constexpr std::string_view StrUpdateReminderTime = "UpdateReminderTime";
+static constexpr std::string_view EnvStrUpdateReminderTime = "BEAMMP_UPDATE_REMINDER_TIME";
 
 TEST_CASE("TConfig::TConfig") {
     const std::string CfgFile = "beammp_server_testconfig.toml";
@@ -263,8 +265,8 @@ void TConfig::ParseFromFile(std::string_view name) {
         TryReadValue(data, "General", StrLogChat, EnvStrLogChat, Settings::Key::General_LogChat);
         TryReadValue(data, "General", StrAllowGuests, EnvStrAllowGuests, Settings::Key::General_AllowGuests);
         // Misc
-        TryReadValue(data, "Misc", StrHideUpdateMessages, "", Settings::Key::Misc_ImScaredOfUpdates);
-        TryReadValue(data, "Misc", StrUpdateReminderTime, "", Settings::Key::Misc_UpdateReminderTime);
+        TryReadValue(data, "Misc", StrHideUpdateMessages, EnvStrHideUpdateMessages, Settings::Key::Misc_ImScaredOfUpdates);
+        TryReadValue(data, "Misc", StrUpdateReminderTime, EnvStrUpdateReminderTime, Settings::Key::Misc_UpdateReminderTime);
 
     } catch (const std::exception& err) {
         beammp_error("Error parsing config file value: " + std::string(err.what()));

--- a/src/TConfig.cpp
+++ b/src/TConfig.cpp
@@ -62,7 +62,7 @@ static constexpr std::string_view StrPassword = "Password";
 
 // Misc
 static constexpr std::string_view StrHideUpdateMessages = "ImScaredOfUpdates";
-static constexpr std::string_view EnvStrHideUpdateMessages = "BEAMMP_HIDE_UPDATE_MESSAGES";
+static constexpr std::string_view EnvStrHideUpdateMessages = "BEAMMP_IM_SCARED_OF_UPDATES";
 static constexpr std::string_view StrUpdateReminderTime = "UpdateReminderTime";
 static constexpr std::string_view EnvStrUpdateReminderTime = "BEAMMP_UPDATE_REMINDER_TIME";
 


### PR DESCRIPTION
Add ENV for missing settings.

Issue: https://github.com/BeamMP/BeamMP-Server/issues/414

Please let me know if there are any issues.

---

By creating this pull request, I understand that code that is AI generated or otherwise automatically generated may be rejected without further discussion.
I declare that I fully understand all code I pushed into this PR, and wrote all this code myself and own the rights to this code.
