### PR TITLE
Force IPv4 for backend requests

### DIFF
--- a/src/Http.cpp
+++ b/src/Http.cpp
@@ -44,6 +44,7 @@ std::string Http::GET(const std::string& url, unsigned int* status) {
         CURLcode res;
         char errbuf[CURL_ERROR_SIZE];
         curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+        curl_easy_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, CurlWriteCallback);
         curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void*)&Ret);
         curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 10); // seconds
@@ -75,6 +76,7 @@ std::string Http::POST(const std::string& url, const std::string& body, const st
         CURLcode res;
         char errbuf[CURL_ERROR_SIZE];
         curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+        curl_easy_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, CurlWriteCallback);
         curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void*)&Ret);
         curl_easy_setopt(curl, CURLOPT_POST, 1);


### PR DESCRIPTION
Force the use of ipv4 for backend requests because the launcher doesn't support ipv6 yet

---

By creating this pull request, I understand that code that is AI generated or otherwise automatically generated may be rejected without further discussion.
I declare that I fully understand all code I pushed into this PR, and wrote all this code myself and own the rights to this code.
