### PR TITLE
Wait for lua and other systems

### DIFF
--- a/src/TLuaEngine.cpp
+++ b/src/TLuaEngine.cpp
@@ -80,10 +80,11 @@ TEST_CASE("TLuaEngine ctor & dtor") {
 
 void TLuaEngine::operator()() {
     RegisterThread("LuaEngine");
-    Application::SetSubsystemStatus("LuaEngine", Application::Status::Good);
     // lua engine main thread
     beammp_infof("Lua v{}.{}.{}", LUA_VERSION_MAJOR, LUA_VERSION_MINOR, LUA_VERSION_RELEASE);
     CollectAndInitPlugins();
+
+    Application::SetSubsystemStatus("LuaEngine", Application::Status::Good);
     // now call all onInit's
     auto Futures = TriggerEvent("onInit", "");
     WaitForAll(Futures, std::chrono::seconds(5));

--- a/src/TNetwork.cpp
+++ b/src/TNetwork.cpp
@@ -307,6 +307,11 @@ std::shared_ptr<TClient> TNetwork::Authentication(TConnection&& RawConnection) {
     Client->SetIdentifier("ip", ip);
     beammp_tracef("This thread is ip {} ({})", ip, RawConnection.SockAddr.address().to_v6().is_v4_mapped() ? "IPv4 mapped IPv6" : "IPv6");
 
+    if (Application::GetSubsystemStatuses().at("Main") == Application::Status::Starting) {
+        ClientKick(*Client, "The server is still starting, please try joining again later.");
+        return nullptr;
+    }
+
     beammp_info("Identifying new ClientConnection...");
 
     auto Data = TCPRcv(*Client);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -182,10 +182,6 @@ int BeamMPServerMain(MainArguments Arguments) {
 
     TServer Server(Arguments.List);
 
-    auto LuaEngine = std::make_shared<TLuaEngine>();
-    LuaEngine->SetServer(&Server);
-    Application::Console().InitializeLuaConsole(*LuaEngine);
-
     RegisterThread("Main");
 
     beammp_trace("Running in debug mode on a debug build");
@@ -194,13 +190,16 @@ int BeamMPServerMain(MainArguments Arguments) {
     TPPSMonitor PPSMonitor(Server);
     THeartbeatThread Heartbeat(ResourceManager, Server);
     TNetwork Network(Server, PPSMonitor, ResourceManager);
+
+    auto LuaEngine = std::make_shared<TLuaEngine>();
+    LuaEngine->SetServer(&Server);
+    Application::Console().InitializeLuaConsole(*LuaEngine);
     LuaEngine->SetNetwork(&Network);
     PPSMonitor.SetNetwork(Network);
     Application::CheckForUpdates();
 
     TPluginMonitor PluginMonitor(fs::path(Application::Settings.getAsString(Settings::Key::General_ResourceFolder)) / "Server", LuaEngine);
 
-    Application::SetSubsystemStatus("Main", Application::Status::Good);
     RegisterThread("Main(Waiting)");
 
     std::set<std::string> IgnoreSubsystems {
@@ -215,6 +214,10 @@ int BeamMPServerMain(MainArguments Arguments) {
             std::string SystemsBadList {};
             auto Statuses = Application::GetSubsystemStatuses();
             for (const auto& NameStatusPair : Statuses) {
+                if (NameStatusPair.first == "Main") {
+                    continue;
+                }
+
                 if (IgnoreSubsystems.count(NameStatusPair.first) > 0) {
                     continue; // ignore
                 }
@@ -228,6 +231,8 @@ int BeamMPServerMain(MainArguments Arguments) {
             // remove ", "
             SystemsBadList = SystemsBadList.substr(0, SystemsBadList.size() - 2);
             if (FullyStarted) {
+                Application::SetSubsystemStatus("Main", Application::Status::Good);
+
                 if (!WithErrors) {
                     beammp_info("ALL SYSTEMS STARTED SUCCESSFULLY, EVERYTHING IS OKAY");
                 } else {


### PR DESCRIPTION
This PR makes it so that connections are denied if lua hasn't loaded yet, and makes it so that lua waits for the server to load before accessing then uninitialized memory.
---

By creating this pull request, I understand that code that is AI generated or otherwise automatically generated may be rejected without further discussion.
I declare that I fully understand all code I pushed into this PR, and wrote all this code myself and own the rights to this code.
