### PR TITLE
Self check functionality

### DIFF
--- a/include/Common.h
+++ b/include/Common.h
@@ -86,6 +86,8 @@ public:
         };
     }
 
+    static std::string GetServerCheckUrl() { return "https://check.beammp.com"; }
+
     static std::string GetBackendUrlForAuth() { return "https://auth.beammp.com"; }
     static std::string GetBackendUrlForSocketIO() { return "https://backend.beammp.com"; }
     static void CheckForUpdates();

--- a/include/TConsole.h
+++ b/include/TConsole.h
@@ -61,6 +61,7 @@ private:
     void Command_Version(const std::string& cmd, const std::vector<std::string>& args);
     void Command_ProtectMod(const std::string& cmd, const std::vector<std::string>& args);
     void Command_ReloadMods(const std::string& cmd, const std::vector<std::string>& args);
+    void Command_NetTest(const std::string& cmd, const std::vector<std::string>& args);
 
     void Command_Say(const std::string& FullCommand);
     bool EnsureArgsCount(const std::vector<std::string>& args, size_t n);
@@ -81,6 +82,7 @@ private:
         { "version", [this](const auto& a, const auto& b) { Command_Version(a, b); } },
         { "protectmod", [this](const auto& a, const auto& b) { Command_ProtectMod(a, b); } },
         { "reloadmods", [this](const auto& a, const auto& b) { Command_ReloadMods(a, b); } },
+        { "nettest", [this](const auto& a, const auto& b) { Command_NetTest(a, b); } },
     };
 
     std::unique_ptr<Commandline> mCommandline { nullptr };

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -24,6 +24,7 @@
 #include "CustomAssert.h"
 #include "LuaAPI.h"
 #include "TLuaEngine.h"
+#include "Http.h"
 
 #include <ctime>
 #include <lua.hpp>
@@ -289,6 +290,30 @@ void TConsole::Command_ReloadMods(const std::string& cmd, const std::vector<std:
 
     mLuaEngine->Network().ResourceManager().RefreshFiles();
     Application::Console().WriteRaw("Mods reloaded.");
+}
+
+void TConsole::Command_NetTest(const std::string& cmd, const std::vector<std::string>& args) {
+    unsigned int status = 0;
+
+    std::string T = Http::GET(
+    Application::GetServerCheckUrl() + "/api/v2/beammp/" + std::to_string(Application::Settings.getAsInt(Settings::Key::General_Port)), &status
+        );
+
+    beammp_debugf("Status and response from Server Check API: {0}, {1}", status, T);
+
+    auto Doc = nlohmann::json::parse(T, nullptr, false);
+
+    if (Doc.is_discarded() || !Doc.is_object()) {
+        beammp_warn("Failed to parse Server Check API response, however the server will most likely still work correctly.");
+    } else {
+        std::string status = Doc["status"];
+        std::string details = "Response from Server Check API: " + std::string(Doc["details"]);
+        if (status == "ok") {
+            beammp_info(details);
+        } else {
+            beammp_warn(details);
+        }
+    }
 }
 
 void TConsole::Command_Kick(const std::string&, const std::vector<std::string>& args) {


### PR DESCRIPTION
This PR adds a new console command (`nettest`) that sends a request to the server check api in order to test connectivity via the server's public ip (serverlist entry).

- [x] https://github.com/BeamMP/ServerCheck/pull/2

---

By creating this pull request, I understand that code that is AI generated or otherwise automatically generated may be rejected without further discussion.
I declare that I fully understand all code I pushed into this PR, and wrote all this code myself and own the rights to this code.
