### PR TITLE
Implement Dialog packet and add MP.ConfirmationDialog

### DIFF
--- a/include/LuaAPI.h
+++ b/include/LuaAPI.h
@@ -36,7 +36,7 @@ namespace MP {
     std::pair<bool, std::string> DropPlayer(int ID, std::optional<std::string> MaybeReason);
     std::pair<bool, std::string> SendChatMessage(int ID, const std::string& Message);
     std::pair<bool, std::string> SendNotification(int ID, const std::string& Message, const std::string& Icon, const std::string& Category);
-    std::pair<bool, std::string> ConfirmationDialog(int ID, const std::string& Title, const std::string& Body, const sol::table& buttons, const std::string& InteractionID, const bool& warning = false);
+    std::pair<bool, std::string> ConfirmationDialog(int ID, const std::string& Title, const std::string& Body, const sol::table& buttons, const std::string& InteractionID, const bool& warning = false, const bool& reportToServer = true, const bool& reportToExtensions = true);
     std::pair<bool, std::string> RemoveVehicle(int PlayerID, int VehicleID);
     void Set(int ConfigID, sol::object NewValue);
     TLuaValue Get(int ConfigID);

--- a/include/LuaAPI.h
+++ b/include/LuaAPI.h
@@ -36,6 +36,7 @@ namespace MP {
     std::pair<bool, std::string> DropPlayer(int ID, std::optional<std::string> MaybeReason);
     std::pair<bool, std::string> SendChatMessage(int ID, const std::string& Message);
     std::pair<bool, std::string> SendNotification(int ID, const std::string& Message, const std::string& Icon, const std::string& Category);
+    std::pair<bool, std::string> ConfirmationDialog(int ID, const std::string& Title, const std::string& Body, const sol::table& buttons, const std::string& InteractionID, const bool& warning = false);
     std::pair<bool, std::string> RemoveVehicle(int PlayerID, int VehicleID);
     void Set(int ConfigID, sol::object NewValue);
     TLuaValue Get(int ConfigID);

--- a/src/LuaAPI.cpp
+++ b/src/LuaAPI.cpp
@@ -241,7 +241,7 @@ std::pair<bool, std::string> LuaAPI::MP::SendNotification(int ID, const std::str
     return Result;
 }
 
-std::pair<bool, std::string> LuaAPI::MP::ConfirmationDialog(int ID, const std::string& Title, const std::string& Body, const sol::table& buttons, const std::string& InteractionID, const bool& warning) {
+std::pair<bool, std::string> LuaAPI::MP::ConfirmationDialog(int ID, const std::string& Title, const std::string& Body, const sol::table& buttons, const std::string& InteractionID, const bool& warning, const bool& reportToServer, const bool& reportToExtensions) {
     std::pair<bool, std::string> Result;
 
     const nlohmann::json PacketBody = {
@@ -249,7 +249,9 @@ std::pair<bool, std::string> LuaAPI::MP::ConfirmationDialog(int ID, const std::s
         { "body", Body },
         { "buttons", nlohmann::json::parse(JsonEncode(buttons), nullptr, false) },
         { "interactionID", InteractionID },
-        { "class", warning ? "experimental" : "" }
+        { "class", warning ? "experimental" : "" },
+        { "reportToServer", reportToServer },
+        { "reportToExtensions", reportToExtensions }
     };
 
     std::string Packet = "D" + PacketBody.dump();

--- a/src/LuaAPI.cpp
+++ b/src/LuaAPI.cpp
@@ -241,6 +241,46 @@ std::pair<bool, std::string> LuaAPI::MP::SendNotification(int ID, const std::str
     return Result;
 }
 
+std::pair<bool, std::string> LuaAPI::MP::ConfirmationDialog(int ID, const std::string& Title, const std::string& Body, const sol::table& buttons, const std::string& InteractionID, const bool& warning) {
+    std::pair<bool, std::string> Result;
+
+    const nlohmann::json PacketBody = {
+        { "title", Title },
+        { "body", Body },
+        { "buttons", nlohmann::json::parse(JsonEncode(buttons), nullptr, false) },
+        { "interactionID", InteractionID },
+        { "class", warning ? "experimental" : "" }
+    };
+
+    std::string Packet = "D" + PacketBody.dump();
+    if (ID == -1) {
+        Engine->Network().SendToAll(nullptr, StringToVector(Packet), true, true);
+        Result.first = true;
+    } else {
+        auto MaybeClient = GetClient(Engine->Server(), ID);
+        if (MaybeClient) {
+            auto c = MaybeClient.value().lock();
+            if (!c->IsSynced()) {
+                Result.first = false;
+                Result.second = "Player is not synced yet";
+                return Result;
+            }
+            if (!Engine->Network().Respond(*c, StringToVector(Packet), true)) {
+                beammp_errorf("Failed to send confirmation dialog to player (id {}) - did the player disconnect?", ID);
+                Result.first = false;
+                Result.second = "Failed to send packet";
+            }
+            Result.first = true;
+        } else {
+            beammp_lua_error("ConfirmationDialog invalid argument [1] invalid ID");
+            Result.first = false;
+            Result.second = "Invalid Player ID";
+        }
+        return Result;
+    }
+    return Result;
+}
+
 std::pair<bool, std::string> LuaAPI::MP::RemoveVehicle(int PID, int VID) {
     std::pair<bool, std::string> Result;
     auto MaybeClient = GetClient(Engine->Server(), PID);

--- a/src/TLuaEngine.cpp
+++ b/src/TLuaEngine.cpp
@@ -876,6 +876,12 @@ TLuaEngine::StateThreadData::StateThreadData(const std::string& Name, TLuaStateI
             beammp_lua_error("SendNotification expects 2, 3 or 4 arguments.");
         }
     });
+    MPTable.set_function("ConfirmationDialog", sol::overload(
+        &LuaAPI::MP::ConfirmationDialog,
+        [&](const int& ID, const std::string& Title, const std::string& Body, const sol::table& Buttons, const std::string& InteractionID) {
+            LuaAPI::MP::ConfirmationDialog(ID, Title, Body, Buttons, InteractionID);
+        }
+    ));
     MPTable.set_function("GetPlayers", [&]() -> sol::table {
         return Lua_GetPlayers();
     });


### PR DESCRIPTION
This PR implements a new lua function and packet used for sends dialogs to the client.

## Example:

https://github.com/user-attachments/assets/97bb5813-ea12-4b1d-a049-2f7ebf6b6da3

Example serverside code:
```lua
--MP.ConfirmationDialog(player_id: number, title: string, body: string, buttons: object, interaction_id: string, warning: boolean = false, reportToServer: boolean = true, reportToExtensions: boolean = true)

function onChatMessage(player_id, player_name, message)
    MP.ConfirmationDialog(player_id, "Warning", "Watch your tone buddy!!", 
        {
            {
                label = "OK",
                key = "dialogOK",
                isCancel = true
            }
        }, "interactionID", true)
end

MP.RegisterEvent("onChatMessage", "onChatMessage")


function dialogOK(player_id, interaction_id)
    MP.SendChatMessage(-1, MP.GetPlayerName(player_id) .. " clicked OK")
end

MP.RegisterEvent("dialogOK", "dialogOK")
```

### Details:
Each dialog can have multiple buttons, each button having it's own callback event (`key`).
Each dialog can also have one button with `isCancel` being true, settings this property to true causes the button's event to be called when the users pressed `esc` to exit out of the dialog. If a dialog is created without any button being the cancel button then the user will only be able to exit the dialog by restarting the session or pressing one of the buttons.

`interaction_id` will be sent as the event data with a button press event, to track from which dialog the button press came. As when multiple dialogs are opened they will stack and it will become difficult to track what button on which dialog was pressed without having multiple event handlers.


Waiting on https://github.com/BeamMP/BeamMP/pull/715 to be merged.

---

By creating this pull request, I understand that code that is AI generated or otherwise automatically generated may be rejected without further discussion.
I declare that I fully understand all code I pushed into this PR, and wrote all this code myself and own the rights to this code.
