### PR TITLE
Make PluginMonitor not try to run non-lua files

### DIFF
--- a/include/Common.h
+++ b/include/Common.h
@@ -131,6 +131,7 @@ private:
 };
 
 void SplitString(std::string const& str, const char delim, std::vector<std::string>& out);
+std::string LowerString(std::string str);
 
 std::string ThreadName(bool DebugModeOverride = false);
 void RegisterThread(const std::string& str);

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -384,6 +384,13 @@ void SplitString(const std::string& str, const char delim, std::vector<std::stri
         out.push_back(str.substr(start, end - start));
     }
 }
+
+std::string LowerString(std::string str) {
+    std::ranges::transform(str, str.begin(), ::tolower);
+    return str;
+}
+
+
 static constexpr size_t STARTING_MAX_DECOMPRESSION_BUFFER_SIZE = 15 * 1024 * 1024;
 static constexpr size_t MAX_DECOMPRESSION_BUFFER_SIZE = 30 * 1024 * 1024;
 

--- a/src/TPluginMonitor.cpp
+++ b/src/TPluginMonitor.cpp
@@ -57,21 +57,26 @@ void TPluginMonitor::operator()() {
                     mFileTimes[Pair.first] = CurrentTime;
                     // grandparent of the path should be Resources/Server
                     if (fs::equivalent(fs::path(Pair.first).parent_path().parent_path(), mPath)) {
-                        beammp_infof("File \"{}\" changed, reloading", Pair.first);
-                        // is in root folder, so reload
-                        std::ifstream FileStream(Pair.first, std::ios::in | std::ios::binary);
-                        auto Size = std::filesystem::file_size(Pair.first);
-                        auto Contents = std::make_shared<std::string>();
-                        Contents->resize(Size);
-                        FileStream.read(Contents->data(), Contents->size());
-                        TLuaChunk Chunk(Contents, Pair.first, fs::path(Pair.first).parent_path().string());
-                        auto StateID = mEngine->GetStateIDForPlugin(fs::path(Pair.first).parent_path());
-                        auto Res = mEngine->EnqueueScript(StateID, Chunk);
-                        Res->WaitUntilReady();
-                        if (Res->Error) {
-                            beammp_lua_errorf("Error while hot-reloading \"{}\": {}", Pair.first, Res->ErrorMessage);
+                        if (fs::path(Pair.first).extension() == ".lua") {
+                            beammp_infof("File \"{}\" changed, reloading", Pair.first);
+                            // is in root folder, so reload
+                            std::ifstream FileStream(Pair.first, std::ios::in | std::ios::binary);
+                            auto Size = std::filesystem::file_size(Pair.first);
+                            auto Contents = std::make_shared<std::string>();
+                            Contents->resize(Size);
+                            FileStream.read(Contents->data(), Contents->size());
+                            TLuaChunk Chunk(Contents, Pair.first, fs::path(Pair.first).parent_path().string());
+                            auto StateID = mEngine->GetStateIDForPlugin(fs::path(Pair.first).parent_path());
+                            auto Res = mEngine->EnqueueScript(StateID, Chunk);
+                            Res->WaitUntilReady();
+                            if (Res->Error) {
+                                beammp_lua_errorf("Error while hot-reloading \"{}\": {}", Pair.first, Res->ErrorMessage);
+                            } else {
+                                mEngine->ReportErrors(mEngine->TriggerLocalEvent(StateID, "onInit"));
+                                mEngine->ReportErrors(mEngine->TriggerEvent("onFileChanged", "", Pair.first));
+                            }
                         } else {
-                            mEngine->ReportErrors(mEngine->TriggerLocalEvent(StateID, "onInit"));
+                            beammp_debugf("File \"{}\" changed, not reloading because it's not a lua file. Triggering 'onFileChanged' event instead", Pair.first);
                             mEngine->ReportErrors(mEngine->TriggerEvent("onFileChanged", "", Pair.first));
                         }
                     } else {

--- a/src/TPluginMonitor.cpp
+++ b/src/TPluginMonitor.cpp
@@ -57,7 +57,7 @@ void TPluginMonitor::operator()() {
                     mFileTimes[Pair.first] = CurrentTime;
                     // grandparent of the path should be Resources/Server
                     if (fs::equivalent(fs::path(Pair.first).parent_path().parent_path(), mPath)) {
-                        if (fs::path(Pair.first).extension() == ".lua") {
+                        if (LowerString(fs::path(Pair.first).extension().string()) == ".lua") {
                             beammp_infof("File \"{}\" changed, reloading", Pair.first);
                             // is in root folder, so reload
                             std::ifstream FileStream(Pair.first, std::ios::in | std::ios::binary);


### PR DESCRIPTION
By creating this pull request, I understand that code that is AI generated or otherwise automatically generated may be rejected without further discussion.
I declare that I fully understand all code I pushed into this PR, and wrote all this code myself and own the rights to this code.
