### PR TITLE
Client resource hash database and client resource protection

### DIFF
--- a/include/TConsole.h
+++ b/include/TConsole.h
@@ -59,6 +59,8 @@ private:
     void Command_Settings(const std::string& cmd, const std::vector<std::string>& args);
     void Command_Clear(const std::string&, const std::vector<std::string>& args);
     void Command_Version(const std::string& cmd, const std::vector<std::string>& args);
+    void Command_ProtectMod(const std::string& cmd, const std::vector<std::string>& args);
+    void Command_ReloadMods(const std::string& cmd, const std::vector<std::string>& args);
 
     void Command_Say(const std::string& FullCommand);
     bool EnsureArgsCount(const std::vector<std::string>& args, size_t n);
@@ -77,6 +79,8 @@ private:
         { "clear", [this](const auto& a, const auto& b) { Command_Clear(a, b); } },
         { "say", [this](const auto&, const auto&) { Command_Say(""); } }, // shouldn't actually be called
         { "version", [this](const auto& a, const auto& b) { Command_Version(a, b); } },
+        { "protectmod", [this](const auto& a, const auto& b) { Command_ProtectMod(a, b); } },
+        { "reloadmods", [this](const auto& a, const auto& b) { Command_ReloadMods(a, b); } },
     };
 
     std::unique_ptr<Commandline> mCommandline { nullptr };

--- a/include/TNetwork.h
+++ b/include/TNetwork.h
@@ -45,6 +45,8 @@ public:
     void SendToAll(TClient* c, const std::vector<uint8_t>& Data, bool Self, bool Rel);
     void UpdatePlayer(TClient& Client);
 
+    TResourceManager& ResourceManager() const { return mResourceManager; }
+
 private:
     void UDPServerMain();
     void TCPServerMain();

--- a/include/TResourceManager.h
+++ b/include/TResourceManager.h
@@ -32,9 +32,8 @@ public:
     [[nodiscard]] int ModsLoaded() const { return mModsLoaded; }
     [[nodiscard]] nlohmann::json GetMods() const { return mMods; }
 
-    [[nodiscard]] std::string NewFileList() const;
-
     void RefreshFiles();
+    void SetProtected(const std::string& ModName, bool Protected);
 
 private:
     size_t mMaxModSize = 0;

--- a/include/TResourceManager.h
+++ b/include/TResourceManager.h
@@ -30,6 +30,7 @@ public:
     [[nodiscard]] std::string TrimmedList() const { return mTrimmedList; }
     [[nodiscard]] std::string FileSizes() const { return mFileSizes; }
     [[nodiscard]] int ModsLoaded() const { return mModsLoaded; }
+    [[nodiscard]] nlohmann::json GetMods() const { return mMods; }
 
     [[nodiscard]] std::string NewFileList() const;
 

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -218,7 +218,7 @@ void TConsole::Command_Help(const std::string&, const std::vector<std::string>& 
         status                     how the server is doing and what it's up to
         clear                      clears the console window
         version                    displays the server version
-        protectmod <name> <value>  sets whether a mod is protected
+        protectmod <name> <value>  sets whether a mod is protected, value can be true or false
         reloadmods                 reloads all mods from the Resources Client folder)";
     Application::Console().WriteRaw("BeamMP-Server Console: " + std::string(sHelpString));
 }

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -208,16 +208,18 @@ void TConsole::Command_Help(const std::string&, const std::vector<std::string>& 
     }
     static constexpr const char* sHelpString = R"(
     Commands:
-        help                    displays this help
-        exit                    shuts down the server
-        kick <name> [reason]    kicks specified player with an optional reason
-        list                    lists all players and info about them
-        say <message>           sends the message to all players in chat
-        lua [state id]          switches to lua, optionally into a specific state id's lua
-        settings [command]      sets or gets settings for the server, run `settings help` for more info
-        status                  how the server is doing and what it's up to
-        clear                   clears the console window
-        version                 displays the server version)";
+        help                       displays this help
+        exit                       shuts down the server
+        kick <name> [reason]       kicks specified player with an optional reason
+        list                       lists all players and info about them
+        say <message>              sends the message to all players in chat
+        lua [state id]             switches to lua, optionally into a specific state id's lua
+        settings [command]         sets or gets settings for the server, run `settings help` for more info
+        status                     how the server is doing and what it's up to
+        clear                      clears the console window
+        version                    displays the server version
+        protectmod <name> <value>  sets whether a mod is protected
+        reloadmods                 reloads all mods from the Resources Client folder)";
     Application::Console().WriteRaw("BeamMP-Server Console: " + std::string(sHelpString));
 }
 
@@ -261,6 +263,32 @@ void TConsole::Command_Version(const std::string& cmd, const std::vector<std::st
     Application::Console().WriteRaw(lua_version);
     std::string openssl_version = fmt::format("OpenSSL:  v{}.{}.{}", OPENSSL_VERSION_MAJOR, OPENSSL_VERSION_MINOR, OPENSSL_VERSION_PATCH);
     Application::Console().WriteRaw(openssl_version);
+}
+void TConsole::Command_ProtectMod(const std::string& cmd, const std::vector<std::string>& args) {
+    if (!EnsureArgsCount(args, 2)) {
+        return;
+    }
+
+    const auto& ModName = args.at(0);
+    const auto& Protect = args.at(1);
+
+    for (auto mod : mLuaEngine->Network().ResourceManager().GetMods()) {
+        if (mod["file_name"].get<std::string>() == ModName) {
+            mLuaEngine->Network().ResourceManager().SetProtected(ModName, Protect == "true");
+            Application::Console().WriteRaw("Mod " + ModName + " is now " + (Protect == "true" ? "protected" : "unprotected"));
+            return;
+        }
+    }
+
+    Application::Console().WriteRaw("Mod " + ModName + " not found.");
+}
+void TConsole::Command_ReloadMods(const std::string& cmd, const std::vector<std::string>& args) {
+    if (!EnsureArgsCount(args, 0)) {
+        return;
+    }
+
+    mLuaEngine->Network().ResourceManager().RefreshFiles();
+    Application::Console().WriteRaw("Mods reloaded.");
 }
 
 void TConsole::Command_Kick(const std::string&, const std::vector<std::string>& args) {

--- a/src/TNetwork.cpp
+++ b/src/TNetwork.cpp
@@ -786,7 +786,7 @@ void TNetwork::Parse(TClient& c, const std::vector<uint8_t>& Packet) {
     case 'S':
         if (SubCode == 'R') {
             beammp_debug("Sending Mod Info");
-            std::string ToSend = mResourceManager.NewFileList();
+            std::string ToSend = mResourceManager.GetMods().dump();
             beammp_debugf("Mod Info: {}", ToSend);
             if (!TCPSend(c, StringToVector(ToSend))) {
                 ClientKick(c, "TCP Send 'SY' failed");

--- a/src/TNetwork.cpp
+++ b/src/TNetwork.cpp
@@ -808,12 +808,16 @@ void TNetwork::SendFile(TClient& c, const std::string& UnsafeName) {
         return;
     }
     auto FileName = fs::path(UnsafeName).filename().string();
-    FileName = Application::Settings.getAsString(Settings::Key::General_ResourceFolder) + "/Client/" + FileName;
 
     for (auto mod : mResourceManager.GetMods()) {
-        if (mod["filename"] == FileName && mod["protected"] == true)
+        if (mod["file_name"].get<std::string>() == FileName && mod["protected"] == true) {
+            beammp_warn("Client tried to access protected file " + UnsafeName);
+            c.Disconnect("Mod is protected thus cannot be downloaded");
             return;
+        }
     }
+
+    FileName = Application::Settings.getAsString(Settings::Key::General_ResourceFolder) + "/Client/" + FileName;
 
     if (!std::filesystem::exists(FileName)) {
         if (!TCPSend(c, StringToVector("CO"))) {

--- a/src/TNetwork.cpp
+++ b/src/TNetwork.cpp
@@ -810,6 +810,11 @@ void TNetwork::SendFile(TClient& c, const std::string& UnsafeName) {
     auto FileName = fs::path(UnsafeName).filename().string();
     FileName = Application::Settings.getAsString(Settings::Key::General_ResourceFolder) + "/Client/" + FileName;
 
+    for (auto mod : mResourceManager.GetMods()) {
+        if (mod["filename"] == FileName && mod["protected"] == true)
+            return;
+    }
+
     if (!std::filesystem::exists(FileName)) {
         if (!TCPSend(c, StringToVector("CO"))) {
             // TODO: handle

--- a/src/TResourceManager.cpp
+++ b/src/TResourceManager.cpp
@@ -58,9 +58,6 @@ TResourceManager::TResourceManager() {
     Application::SetSubsystemStatus("ResourceManager", Application::Status::Good);
 }
 
-std::string TResourceManager::NewFileList() const {
-    return mMods.dump();
-}
 void TResourceManager::RefreshFiles() {
     mMods.clear();
     std::unique_lock Lock(mModsMutex);

--- a/src/TResourceManager.cpp
+++ b/src/TResourceManager.cpp
@@ -94,10 +94,12 @@ void TResourceManager::RefreshFiles() {
         }
 
         if (modsDB.contains(entry.path().filename().string())) {
-            auto dbEntry = modsDB[entry.path().filename().string()];
+            auto& dbEntry = modsDB[entry.path().filename().string()];
             if (entry.last_write_time().time_since_epoch().count() > dbEntry["lastwrite"] || std::filesystem::file_size(File) != dbEntry["filesize"].get<size_t>()) {
                 beammp_infof("File '{}' has been modified, rehashing", File);
             } else {
+                dbEntry["exists"] = true;
+
                 mMods.push_back(nlohmann::json {
                 { "file_name", std::filesystem::path(File).filename() },
                 { "file_size", std::filesystem::file_size(File) },
@@ -178,11 +180,21 @@ void TResourceManager::RefreshFiles() {
                 { "lastwrite", entry.last_write_time().time_since_epoch().count() },
                 { "hash", result },
                 { "filesize", std::filesystem::file_size(File) },
-                { "protected", false }
+                { "protected", false },
+                { "exists", true }
             };
 
         } catch (const std::exception& e) {
             beammp_errorf("Sha256 hashing of '{}' failed: {}", File, e.what());
+        }
+    }
+
+    for (auto it = modsDB.begin(); it != modsDB.end(); ) {
+        if (!it.value().contains("exists")) {
+            it = modsDB.erase(it);
+        } else {
+            it.value().erase("exists");
+            ++it;
         }
     }
 

--- a/src/TResourceManager.cpp
+++ b/src/TResourceManager.cpp
@@ -66,12 +66,50 @@ void TResourceManager::RefreshFiles() {
     std::unique_lock Lock(mModsMutex);
 
     std::string Path = Application::Settings.getAsString(Settings::Key::General_ResourceFolder) + "/Client";
+
+    nlohmann::json modsDB;
+
+    if (std::filesystem::exists(Path + "/mods.json")) {
+        try {
+            std::ifstream stream(Path + "/mods.json");
+
+            stream >> modsDB;
+
+            stream.close();
+        } catch (const std::exception& e) {
+            beammp_errorf("Failed to load mods.json: {}", e.what());
+        }
+    }
+
     for (const auto& entry : fs::directory_iterator(Path)) {
         std::string File(entry.path().string());
+
+        if (entry.path().filename().string() == "mods.json") {
+            continue;
+        }
 
         if (entry.path().extension() != ".zip" || std::filesystem::is_directory(entry.path())) {
             beammp_warnf("'{}' is not a ZIP file and will be ignored", File);
             continue;
+        }
+
+        if (modsDB.contains(entry.path().filename().string())) {
+            auto dbEntry = modsDB[entry.path().filename().string()];
+            if (entry.last_write_time().time_since_epoch().count() > dbEntry["lastwrite"] || std::filesystem::file_size(File) != dbEntry["filesize"].get<size_t>()) {
+                beammp_infof("File '{}' has been modified, rehashing", File);
+            } else {
+                mMods.push_back(nlohmann::json {
+                { "file_name", std::filesystem::path(File).filename() },
+                { "file_size", std::filesystem::file_size(File) },
+                { "hash_algorithm", "sha256" },
+                { "hash", dbEntry["hash"] },
+                { "protected", dbEntry["protected"] }
+                });
+
+                beammp_debugf("Mod '{}' loaded from cache", File);
+
+                continue;
+            }
         }
 
         try {
@@ -133,9 +171,28 @@ void TResourceManager::RefreshFiles() {
                 { "file_size", std::filesystem::file_size(File) },
                 { "hash_algorithm", "sha256" },
                 { "hash", result },
+                { "protected", false }
             });
+
+            modsDB[std::filesystem::path(File).filename().string()] = {
+                { "lastwrite", entry.last_write_time().time_since_epoch().count() },
+                { "hash", result },
+                { "filesize", std::filesystem::file_size(File) },
+                { "protected", false }
+            };
+
         } catch (const std::exception& e) {
             beammp_errorf("Sha256 hashing of '{}' failed: {}", File, e.what());
         }
+    }
+
+    try {
+        std::ofstream stream(Path + "/mods.json");
+
+        stream << modsDB.dump(4);
+
+        stream.close();
+    } catch (std::exception& e) {
+        beammp_error("Failed to update mod DB: " + std::string(e.what()));
     }
 }

--- a/src/TResourceManager.cpp
+++ b/src/TResourceManager.cpp
@@ -98,12 +98,11 @@ void TResourceManager::RefreshFiles() {
                 dbEntry["exists"] = true;
 
                 mMods.push_back(nlohmann::json {
-                { "file_name", std::filesystem::path(File).filename() },
-                { "file_size", std::filesystem::file_size(File) },
-                { "hash_algorithm", "sha256" },
-                { "hash", dbEntry["hash"] },
-                { "protected", dbEntry["protected"] }
-                });
+                    { "file_name", std::filesystem::path(File).filename() },
+                    { "file_size", std::filesystem::file_size(File) },
+                    { "hash_algorithm", "sha256" },
+                    { "hash", dbEntry["hash"] },
+                    { "protected", dbEntry["protected"] } });
 
                 beammp_debugf("Mod '{}' loaded from cache", File);
 
@@ -170,8 +169,7 @@ void TResourceManager::RefreshFiles() {
                 { "file_size", std::filesystem::file_size(File) },
                 { "hash_algorithm", "sha256" },
                 { "hash", result },
-                { "protected", false }
-            });
+                { "protected", false } });
 
             modsDB[std::filesystem::path(File).filename().string()] = {
                 { "lastwrite", entry.last_write_time().time_since_epoch().count() },
@@ -186,7 +184,7 @@ void TResourceManager::RefreshFiles() {
         }
     }
 
-    for (auto it = modsDB.begin(); it != modsDB.end(); ) {
+    for (auto it = modsDB.begin(); it != modsDB.end();) {
         if (!it.value().contains("exists")) {
             it = modsDB.erase(it);
         } else {
@@ -203,5 +201,41 @@ void TResourceManager::RefreshFiles() {
         stream.close();
     } catch (std::exception& e) {
         beammp_error("Failed to update mod DB: " + std::string(e.what()));
+    }
+}
+
+void TResourceManager::SetProtected(const std::string& ModName, bool Protected) {
+    std::unique_lock Lock(mModsMutex);
+
+    for (auto& mod : mMods) {
+        if (mod["file_name"].get<std::string>() == ModName) {
+            mod["protected"] = Protected;
+            break;
+        }
+    }
+
+    auto modsDBPath = Application::Settings.getAsString(Settings::Key::General_ResourceFolder) + "/Client/mods.json";
+
+    if (std::filesystem::exists(modsDBPath)) {
+        try {
+            nlohmann::json modsDB;
+
+            std::fstream stream(modsDBPath);
+
+            stream >> modsDB;
+
+            if (modsDB.contains(ModName)) {
+                modsDB[ModName]["protected"] = Protected;
+            }
+
+            stream.clear();
+            stream.seekp(0, std::ios::beg);
+
+            stream << modsDB.dump(4);
+
+            stream.close();
+        } catch (const std::exception& e) {
+            beammp_errorf("Failed to update mods.json: {}", e.what());
+        }
     }
 }


### PR DESCRIPTION
# Mod database
This PR adds a local database of mods, which is used to cache mod hashes and protection status.

## Mod hash caching
Mod hashes will now be cached based on last write date. This will speed up server startup because only the mods with changes will have to be hashed.

## Mod protection
You can now protect mods! This will allow you to host a server with copyrighted content without actually hosting the copyrighted content. Just run `protectmod <filename with .zip> <true/false>` in the console to protect a mod. Users that join a server with protected mods will have to obtain the file themselves and put it in their launcher's resources folder. The launcher will inform the user about this if the file is missing.

## Mod reloading
You can now reload client mods while the server is running by using `reloadmods` in the console. Keep in mind that this is mainly intended for development, therefore it will **not** force client to rejoin and neither will is hot-reload mods on the client.

---

By creating this pull request, I understand that code that is AI generated or otherwise automatically generated may be rejected without further discussion.
I declare that I fully understand all code I pushed into this PR, and wrote all this code myself and own the rights to this code.
