### PR TITLE
Prevent lua sending client events during downloading

### DIFF
--- a/src/LuaAPI.cpp
+++ b/src/LuaAPI.cpp
@@ -148,6 +148,11 @@ static inline std::pair<bool, std::string> InternalTriggerClientEvent(int Player
             return { false, "Invalid Player ID" };
         }
         auto c = MaybeClient.value().lock();
+
+        if (!c->IsSyncing() && !c->IsSynced()) {
+            return { false, "Player hasn't joined yet" };
+        }
+
         if (!LuaAPI::MP::Engine->Network().Respond(*c, StringToVector(Packet), true)) {
             beammp_lua_errorf("Respond failed, dropping client {}", PlayerID);
             LuaAPI::MP::Engine->Network().ClientKick(*c, "Disconnected after failing to receive packets");


### PR DESCRIPTION
This PR fixes an issue where players would get personal events during downloads, which would corrupt the download and block the user from being able to properly join the server.

---

By creating this pull request, I understand that code that is AI generated or otherwise automatically generated may be rejected without further discussion.
I declare that I fully understand all code I pushed into this PR, and wrote all this code myself and own the rights to this code.
