### PR TITLE
Provider env ip

### DIFF
--- a/include/Env.h
+++ b/include/Env.h
@@ -27,6 +27,7 @@ enum class Key {
     PROVIDER_UPDATE_MESSAGE,
     PROVIDER_DISABLE_CONFIG,
     PROVIDER_PORT_ENV,
+    PROVIDER_IP_ENV
 };
 
 std::optional<std::string> Get(Key key);

--- a/src/Env.cpp
+++ b/src/Env.cpp
@@ -39,6 +39,9 @@ std::string_view Env::ToString(Env::Key key) {
     case Key::PROVIDER_PORT_ENV:
         return "BEAMMP_PROVIDER_PORT_ENV";
         break;
+    case Key::PROVIDER_IP_ENV:
+        return "BEAMMP_PROVIDER_IP_ENV";
+        break;
     }
     return "";
 }

--- a/src/TConfig.cpp
+++ b/src/TConfig.cpp
@@ -309,6 +309,7 @@ void TConfig::PrintDebug() {
     beammp_debug(std::string(StrPrivate) + ": " + std::string(Application::Settings.getAsBool(Settings::Key::General_Private) ? "true" : "false"));
     beammp_debug(std::string(StrInformationPacket) + ": " + std::string(Application::Settings.getAsBool(Settings::Key::General_InformationPacket) ? "true" : "false"));
     beammp_debug(std::string(StrPort) + ": " + std::to_string(Application::Settings.getAsInt(Settings::Key::General_Port)));
+    beammp_debug(std::string(StrIP) + ": \"" + Application::Settings.getAsString(Settings::Key::General_IP) + "\"");
     beammp_debug(std::string(StrMaxCars) + ": " + std::to_string(Application::Settings.getAsInt(Settings::Key::General_MaxCars)));
     beammp_debug(std::string(StrMaxPlayers) + ": " + std::to_string(Application::Settings.getAsInt(Settings::Key::General_MaxPlayers)));
     beammp_debug(std::string(StrMap) + ": \"" + Application::Settings.getAsString(Settings::Key::General_Map) + "\"");

--- a/src/TConfig.cpp
+++ b/src/TConfig.cpp
@@ -258,7 +258,11 @@ void TConfig::ParseFromFile(std::string_view name) {
         } else {
             TryReadValue(data, "General", StrPort, EnvStrPort, Settings::Key::General_Port);
         }
-        TryReadValue(data, "General", StrIP, EnvStrIP, Settings::Key::General_IP);
+        if (Env::Get(Env::Key::PROVIDER_IP_ENV).has_value()) {
+            TryReadValue(data, "General", StrIP, Env::Get(Env::Key::PROVIDER_IP_ENV).value(), Settings::Key::General_IP);
+        } else {
+            TryReadValue(data, "General", StrIP, EnvStrIP, Settings::Key::General_IP);
+        }
         TryReadValue(data, "General", StrMaxCars, EnvStrMaxCars, Settings::Key::General_MaxCars);
         TryReadValue(data, "General", StrMaxPlayers, EnvStrMaxPlayers, Settings::Key::General_MaxPlayers);
         TryReadValue(data, "General", StrMap, EnvStrMap, Settings::Key::General_Map);


### PR DESCRIPTION
Adds `BEAMMP_PROVIDER_IP_ENV` for hosting panels, which allows the server owner to configure which env var is read to get the ip interface to bind to.

---

By creating this pull request, I understand that code that is AI generated or otherwise automatically generated may be rejected without further discussion.
I declare that I fully understand all code I pushed into this PR, and wrote all this code myself and own the rights to this code.
