### PR TITLE
refactor: optimize string operations and improve code clarity

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -160,7 +160,7 @@ void TConsole::ChangeToRegularConsole() {
 }
 
 bool TConsole::EnsureArgsCount(const std::vector<std::string>& args, size_t n) {
-    if (n == 0 && args.size() != 0) {
+    if (n == 0 && !args.empty()) {
         Application::Console().WriteRaw("This command expects no arguments.");
         return false;
     } else if (args.size() != n) {
@@ -198,7 +198,7 @@ void TConsole::Command_Lua(const std::string&, const std::vector<std::string>& a
         } else {
             Application::Console().WriteRaw("Lua state '" + NewStateId + "' is not a known state. Didn't switch to Lua.");
         }
-    } else if (args.size() == 0) {
+    } else if (args.empty()) {
         ChangeToLuaConsole(mDefaultStateId);
     }
 }
@@ -423,7 +423,7 @@ void TConsole::Command_Settings(const std::string&, const std::vector<std::strin
         settings set <category> <setting> <value>   sets specified setting to value
         )";
 
-    if (args.size() == 0) {
+    if (args.empty()) {
         beammp_errorf("No arguments specified for command 'settings'!");
         Application::Console().WriteRaw("BeamMP-Server Console: " + std::string(sHelpString));
         return;
@@ -705,7 +705,7 @@ void TConsole::RunAsCommand(const std::string& cmd, bool IgnoreNotACommand) {
             }
         }
     }
-    if (NonNilFutures.size() == 0) {
+    if (NonNilFutures.empty()) {
         if (!IgnoreNotACommand) {
             Application::Console().WriteRaw("Error: Unknown command: '" + cmd + "'. Type 'help' to see a list of valid commands.");
         }

--- a/src/TLuaEngine.cpp
+++ b/src/TLuaEngine.cpp
@@ -131,7 +131,7 @@ void TLuaEngine::operator()() {
                 }
             }
         }
-        if (mLuaStates.size() == 0) {
+        if (mLuaStates.empty()) {
             beammp_trace("No Lua states, event loop running extremely sparsely");
             Application::SleepSafeSeconds(10);
         } else {

--- a/src/TServer.cpp
+++ b/src/TServer.cpp
@@ -198,7 +198,8 @@ void TServer::GlobalParser(const std::weak_ptr<TClient>& Client, std::vector<uin
         int PID = -1;
         int VID = -1;
 
-        auto MaybePidVid = GetPidVid(StringPacket.substr(3).substr(0, StringPacket.substr(3).find(':', 1)));
+        auto pidVidPart = StringPacket.substr(3);
+        auto MaybePidVid = GetPidVid(pidVidPart.substr(0, pidVidPart.find(':')));
         if (MaybePidVid) {
             std::tie(PID, VID) = MaybePidVid.value();
         }
@@ -289,7 +290,8 @@ void TServer::GlobalParser(const std::weak_ptr<TClient>& Client, std::vector<uin
         int PID = -1;
         int VID = -1;
 
-        auto MaybePidVid = GetPidVid(StringPacket.substr(3).substr(0, StringPacket.substr(3).find(':', 1)));
+        auto pidVidPart = StringPacket.substr(3);
+        auto MaybePidVid = GetPidVid(pidVidPart.substr(0, pidVidPart.find(':')));
         if (MaybePidVid) {
             std::tie(PID, VID) = MaybePidVid.value();
         }


### PR DESCRIPTION
- Avoid redundant substr() calls in packet parsing hot-path (TServer.cpp)
  The previous code called substr(3) twice per packet, creating
  unnecessary temporary strings. Now stores the result once.

- Replace .size() == 0 with .empty() for idiomatic C++
  (TConsole.cpp, TLuaEngine.cpp)
