### PR TITLE
feature: BEAMMP_PROVIDER_DISABLE_MP_SET environment variable

### DIFF
--- a/include/Env.h
+++ b/include/Env.h
@@ -26,6 +26,7 @@ enum class Key {
     // provider settings
     PROVIDER_UPDATE_MESSAGE,
     PROVIDER_DISABLE_CONFIG,
+    PROVIDER_DISABLE_MP_SET,
     PROVIDER_PORT_ENV,
     PROVIDER_IP_ENV
 };

--- a/src/Env.cpp
+++ b/src/Env.cpp
@@ -36,6 +36,9 @@ std::string_view Env::ToString(Env::Key key) {
     case Key::PROVIDER_DISABLE_CONFIG:
         return "BEAMMP_PROVIDER_DISABLE_CONFIG";
         break;
+    case Key::PROVIDER_DISABLE_MP_SET:
+        return "BEAMMP_PROVIDER_DISABLE_MP_SET";
+        break;
     case Key::PROVIDER_PORT_ENV:
         return "BEAMMP_PROVIDER_PORT_ENV";
         break;

--- a/src/TLuaEngine.cpp
+++ b/src/TLuaEngine.cpp
@@ -22,6 +22,7 @@
 #include "CustomAssert.h"
 #include "Http.h"
 #include "LuaAPI.h"
+#include "Env.h"
 #include "Profiling.h"
 #include "TLuaPlugin.h"
 #include "sol/object.hpp"
@@ -733,6 +734,25 @@ static void AddToTable(sol::table& table, const std::string& left, const T& valu
     }
 }
 
+static bool mDisableMPSet = [] {
+    auto DisableMPSet = Env::Get(Env::Key::PROVIDER_DISABLE_MP_SET).value_or("false");
+    return DisableMPSet == "true" || DisableMPSet == "1";
+}();
+
+static auto GetSettingName = [](int id) -> const char* {
+    switch (id) {
+        case 0: return "Debug";
+        case 1: return "Private";
+        case 2: return "MaxCars";
+        case 3: return "MaxPlayers";
+        case 4: return "Map";
+        case 5: return "Name";
+        case 6: return "Description";
+        case 7: return "InformationPacket";
+        default: return "Unknown";
+    }
+};
+
 static void JsonDecodeRecursive(sol::state_view& StateView, sol::table& table, const std::string& left, const nlohmann::json& right) {
     switch (right.type()) {
     case nlohmann::detail::value_t::null:
@@ -925,7 +945,13 @@ TLuaEngine::StateThreadData::StateThreadData(const std::string& Name, TLuaStateI
     MPTable.set_function("CancelEventTimer", [&](const std::string& EventName) {
         mEngine->CancelEventTimers(EventName, mStateId);
     });
-    MPTable.set_function("Set", &LuaAPI::MP::Set);
+    if (mDisableMPSet) {
+        MPTable.set_function("Set", [this](int ConfigID, sol::object NewValue) {
+            beammp_lua_errorf("A script ({}) tried to call MP.Set to change setting '{}' but this was blocked by your server provider.", mStateId, GetSettingName(ConfigID));
+        });
+    } else {
+        MPTable.set_function("Set", &LuaAPI::MP::Set);
+    }
     MPTable.set_function("Get", &LuaAPI::MP::Get);
 
     auto UtilTable = StateView.create_named_table("Util");


### PR DESCRIPTION
This pull request adds BEAMMP_PROVIDER_DISABLE_MP_SET variable (true/false/1/0) to disable MP::Set for providers.

---

By creating this pull request, I understand that code that is AI generated or otherwise automatically generated may be rejected without further discussion.
I declare that I fully understand all code I pushed into this PR, and wrote all this code myself and own the rights to this code.
