### PR TITLE
RegisterEvent anonymous functions implementation (Additionally prevent CreateEventTimer() to register the same event more than one time)

### DIFF
--- a/include/Common.h
+++ b/include/Common.h
@@ -36,11 +36,12 @@
 
 #include <doctest/doctest.h>
 #include <filesystem>
+#include <sol/sol.hpp>
 namespace fs = std::filesystem;
 
 #include "Settings.h"
 #include "TConsole.h"
-
+using LuaFunction = std::variant<sol::main_protected_function, std::string>;
 struct Version {
     uint8_t major;
     uint8_t minor;
@@ -267,7 +268,7 @@ void LogChatMessage(const std::string& name, int id, const std::string& msg);
 
 std::vector<uint8_t> Comp(std::span<const uint8_t> input);
 std::vector<uint8_t> DeComp(std::span<const uint8_t> input);
-
+std::string GetFunctionName(const LuaFunction& cb);
 std::string GetPlatformAgnosticErrorString();
 #define S_DSN SU_RAW
 

--- a/include/Common.h
+++ b/include/Common.h
@@ -41,7 +41,7 @@ namespace fs = std::filesystem;
 
 #include "Settings.h"
 #include "TConsole.h"
-using LuaFunction = std::variant<sol::main_protected_function, std::string>;
+using LuaFunction = std::variant<std::shared_ptr<sol::main_protected_function>, std::string>;
 struct Version {
     uint8_t major;
     uint8_t minor;

--- a/include/TLuaEngine.h
+++ b/include/TLuaEngine.h
@@ -203,7 +203,7 @@ public:
     [[nodiscard]] std::vector<std::shared_ptr<TLuaResult>> TriggerLocalEvent(const TLuaStateId& StateId, const std::string& EventName, ArgsT&&... Args) {
         std::unique_lock Lock(mLuaEventsMutex);
         beammp_event(EventName + " in '" + StateId + "'");
-        if (mLuaEvents.find(EventName) == mLuaEvents.end()) { // if no event handler is defined for 'EventName', return immediately
+        if (!mLuaEvents.contains(EventName)) { // if no event handler is defined for 'EventName', return immediately
             return {};
         }
         std::vector<std::shared_ptr<TLuaResult>> Results;
@@ -214,7 +214,7 @@ public:
         }
         return Results;
     }
-    std::vector<std::variant<sol::basic_protected_function<sol::basic_reference<true>>, std::string>> GetEventHandlersForState(const std::string& EventName, TLuaStateId StateId);
+    std::vector<std::variant<std::shared_ptr<sol::basic_protected_function<sol::basic_reference<true>>>, std::string>> GetEventHandlersForState(const std::string& EventName, TLuaStateId StateId);
     void CreateEventTimer(const std::string& EventName, TLuaStateId StateId, size_t IntervalMS, CallStrategy Strategy);
     void CancelEventTimers(const std::string& EventName, TLuaStateId StateId);
     sol::state_view GetStateForPlugin(const fs::path& PluginPath);

--- a/include/TLuaEngine.h
+++ b/include/TLuaEngine.h
@@ -36,6 +36,7 @@
 #include <set>
 #include <toml.hpp>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #define SOL_ALL_SAFETIES_ON 1
@@ -76,7 +77,7 @@ struct TLuaResult {
     std::string ErrorMessage;
     sol::object Result { sol::lua_nil };
     TLuaStateId StateId;
-    sol::object Function;
+    LuaFunction Function;
     std::shared_ptr<std::mutex> ReadyMutex {
         std::make_shared<std::mutex>()
     };
@@ -112,7 +113,7 @@ public:
     };
 
     struct QueuedFunction {
-        sol::object FunctionObject;
+        LuaFunction FunctionObject;
         std::shared_ptr<TLuaResult> Result;
         std::vector<TLuaValue> Args;
         std::string EventName; // optional, may be empty
@@ -167,9 +168,9 @@ public:
     void ReportErrors(const std::vector<std::shared_ptr<TLuaResult>>& Results);
     bool HasState(TLuaStateId StateId);
     [[nodiscard]] std::shared_ptr<TLuaResult> EnqueueScript(TLuaStateId StateID, const TLuaChunk& Script);
-    [[nodiscard]] std::shared_ptr<TLuaResult> EnqueueFunctionCall(TLuaStateId StateID, const sol::object& FunctionObject, const std::vector<TLuaValue>& Args, const std::string& EventName);
+    [[nodiscard]] std::shared_ptr<TLuaResult> EnqueueFunctionCall(TLuaStateId StateID, const LuaFunction& FunctionObject, const std::vector<TLuaValue>& Args, const std::string& EventName);
     void EnsureStateExists(TLuaStateId StateId, const std::string& Name, bool DontCallOnInit = false);
-    void RegisterEvent(const std::string& EventName, TLuaStateId StateId, const sol::object& FunctionObject);
+    void RegisterEvent(const std::string& EventName, TLuaStateId StateId, const LuaFunction& FunctionObject);
     /**
      *
      * @tparam ArgsT Template Arguments for the event (Metadata) todo: figure out what this means
@@ -182,7 +183,7 @@ public:
     [[nodiscard]] std::vector<std::shared_ptr<TLuaResult>> TriggerEvent(const std::string& EventName, TLuaStateId IgnoreId, ArgsT&&... Args) {
         std::unique_lock Lock(mLuaEventsMutex);
         beammp_event(EventName);
-        if (mLuaEvents.find(EventName) == mLuaEvents.end()) { // if no event handler is defined for 'EventName', return immediately
+        if (!mLuaEvents.contains(EventName)) { // if no event handler is defined for 'EventName', return immediately
             return {};
         }
 
@@ -213,7 +214,7 @@ public:
         }
         return Results;
     }
-    std::vector<sol::basic_object<sol::basic_reference<>>> GetEventHandlersForState(const std::string& EventName, TLuaStateId StateId);
+    std::vector<std::variant<sol::basic_protected_function<sol::basic_reference<true>>, std::string>> GetEventHandlersForState(const std::string& EventName, TLuaStateId StateId);
     void CreateEventTimer(const std::string& EventName, TLuaStateId StateId, size_t IntervalMS, CallStrategy Strategy);
     void CancelEventTimers(const std::string& EventName, TLuaStateId StateId);
     sol::state_view GetStateForPlugin(const fs::path& PluginPath);
@@ -226,7 +227,7 @@ public:
     std::vector<std::string> GetStateTableKeysForState(TLuaStateId StateId, std::vector<std::string> keys);
 
     // Debugging functions (slow)
-    std::unordered_map<std::string /*event name */, std::vector<sol::object> /* handlers */> Debug_GetEventsForState(TLuaStateId StateId);
+    std::unordered_map<std::string /*event name */, std::vector<LuaFunction> /* handlers */> Debug_GetEventsForState(TLuaStateId StateId);
     std::queue<std::pair<TLuaChunk, std::shared_ptr<TLuaResult>>> Debug_GetStateExecuteQueueForState(TLuaStateId StateId);
     std::deque<QueuedFunction> Debug_GetStateFunctionQueueForState(TLuaStateId StateId);
     std::vector<TLuaResult> Debug_GetResultsToCheckForState(TLuaStateId StateId);
@@ -243,9 +244,9 @@ private:
         StateThreadData(const StateThreadData&) = delete;
         virtual ~StateThreadData() noexcept { beammp_debug("\"" + mStateId + "\" destroyed"); }
         [[nodiscard]] std::shared_ptr<TLuaResult> EnqueueScript(const TLuaChunk& Script);
-        [[nodiscard]] std::shared_ptr<TLuaResult> EnqueueFunctionCall(const sol::object& FunctionObject, const std::vector<TLuaValue>& Args, const std::string& EventName);
-        [[nodiscard]] std::shared_ptr<TLuaResult> EnqueueFunctionCallFromCustomEvent(const sol::object& FunctionObject, const std::vector<TLuaValue>& Args, const std::string& EventName, CallStrategy Strategy);
-        void RegisterEvent(const std::string& EventName, const sol::object& FunctionObject) const;
+        [[nodiscard]] std::shared_ptr<TLuaResult> EnqueueFunctionCall(const LuaFunction& FunctionObject, const std::vector<TLuaValue>& Args, const std::string& EventName);
+        [[nodiscard]] std::shared_ptr<TLuaResult> EnqueueFunctionCallFromCustomEvent(const LuaFunction& FunctionObject, const std::vector<TLuaValue>& Args, const std::string& EventName, CallStrategy Strategy);
+        void RegisterEvent(const std::string& EventName, const LuaFunction& FunctionObject) const;
         void AddPath(const fs::path& Path); // to be added to path and cpath
         void operator()() override;
         sol::state_view State() { return sol::state_view(mState); }
@@ -309,7 +310,7 @@ private:
     std::vector<std::shared_ptr<TLuaPlugin>> mLuaPlugins;
     std::unordered_map<TLuaStateId, std::unique_ptr<StateThreadData>> mLuaStates;
     std::recursive_mutex mLuaStatesMutex;
-    std::unordered_map<std::string /* event name */, std::unordered_map<TLuaStateId, std::vector<sol::object>>> mLuaEvents;
+    std::unordered_map<std::string, std::unordered_map<TLuaStateId, std::vector<LuaFunction>>> mLuaEvents;
     std::recursive_mutex mLuaEventsMutex;
     std::vector<TimedEvent> mTimedEvents;
     std::recursive_mutex mTimedEventsMutex;

--- a/include/TLuaEngine.h
+++ b/include/TLuaEngine.h
@@ -283,7 +283,7 @@ private:
         std::thread mThread;
         std::queue<std::pair<TLuaChunk, std::shared_ptr<TLuaResult>>> mStateExecuteQueue;
         std::recursive_mutex mStateExecuteQueueMutex;
-        std::deque<QueuedFunction> mStateFunctionQueue;
+        std::deque<QueuedFunction> mStateFunctionQueue; //This has been changed from vector to deque; it has been benchmarked and improves the queue performance by a lot
         std::mutex mStateFunctionQueueMutex;
         std::condition_variable mStateFunctionQueueCond;
         TLuaEngine* mEngine;

--- a/include/TLuaEngine.h
+++ b/include/TLuaEngine.h
@@ -228,7 +228,7 @@ public:
     // Debugging functions (slow)
     std::unordered_map<std::string /*event name */, std::vector<sol::object> /* handlers */> Debug_GetEventsForState(TLuaStateId StateId);
     std::queue<std::pair<TLuaChunk, std::shared_ptr<TLuaResult>>> Debug_GetStateExecuteQueueForState(TLuaStateId StateId);
-    std::vector<QueuedFunction> Debug_GetStateFunctionQueueForState(TLuaStateId StateId);
+    std::deque<QueuedFunction> Debug_GetStateFunctionQueueForState(TLuaStateId StateId);
     std::vector<TLuaResult> Debug_GetResultsToCheckForState(TLuaStateId StateId);
 
 private:
@@ -255,7 +255,7 @@ private:
 
         // Debug functions, slow
         std::queue<std::pair<TLuaChunk, std::shared_ptr<TLuaResult>>> Debug_GetStateExecuteQueue();
-        std::vector<TLuaEngine::QueuedFunction> Debug_GetStateFunctionQueue();
+        std::deque<TLuaEngine::QueuedFunction> Debug_GetStateFunctionQueue();
 
     private:
         sol::table Lua_TriggerGlobalEvent(const std::string& EventName, sol::variadic_args EventArgs);
@@ -281,7 +281,7 @@ private:
         std::thread mThread;
         std::queue<std::pair<TLuaChunk, std::shared_ptr<TLuaResult>>> mStateExecuteQueue;
         std::recursive_mutex mStateExecuteQueueMutex;
-        std::vector<QueuedFunction> mStateFunctionQueue;
+        std::deque<QueuedFunction> mStateFunctionQueue;
         std::mutex mStateFunctionQueueMutex;
         std::condition_variable mStateFunctionQueueCond;
         TLuaEngine* mEngine;

--- a/include/TLuaEngine.h
+++ b/include/TLuaEngine.h
@@ -219,6 +219,7 @@ public:
     void CancelEventTimers(const std::string& EventName, TLuaStateId StateId);
     sol::state_view GetStateForPlugin(const fs::path& PluginPath);
     TLuaStateId GetStateIDForPlugin(const fs::path& PluginPath);
+    void ClearEventsForState(const std::string& StateID);
     void AddResultToCheck(const std::shared_ptr<TLuaResult>& Result);
 
     static constexpr const char* BeamMPFnNotFoundError = "BEAMMP_FN_NOT_FOUND";

--- a/include/TLuaEngine.h
+++ b/include/TLuaEngine.h
@@ -76,7 +76,7 @@ struct TLuaResult {
     std::string ErrorMessage;
     sol::object Result { sol::lua_nil };
     TLuaStateId StateId;
-    std::string Function;
+    sol::object Function;
     std::shared_ptr<std::mutex> ReadyMutex {
         std::make_shared<std::mutex>()
     };
@@ -112,7 +112,7 @@ public:
     };
 
     struct QueuedFunction {
-        std::string FunctionName;
+        sol::object FunctionObject;
         std::shared_ptr<TLuaResult> Result;
         std::vector<TLuaValue> Args;
         std::string EventName; // optional, may be empty
@@ -167,9 +167,9 @@ public:
     void ReportErrors(const std::vector<std::shared_ptr<TLuaResult>>& Results);
     bool HasState(TLuaStateId StateId);
     [[nodiscard]] std::shared_ptr<TLuaResult> EnqueueScript(TLuaStateId StateID, const TLuaChunk& Script);
-    [[nodiscard]] std::shared_ptr<TLuaResult> EnqueueFunctionCall(TLuaStateId StateID, const std::string& FunctionName, const std::vector<TLuaValue>& Args, const std::string& EventName);
+    [[nodiscard]] std::shared_ptr<TLuaResult> EnqueueFunctionCall(TLuaStateId StateID, const sol::object& FunctionObject, const std::vector<TLuaValue>& Args, const std::string& EventName);
     void EnsureStateExists(TLuaStateId StateId, const std::string& Name, bool DontCallOnInit = false);
-    void RegisterEvent(const std::string& EventName, TLuaStateId StateId, const std::string& FunctionName);
+    void RegisterEvent(const std::string& EventName, TLuaStateId StateId, const sol::object& FunctionObject);
     /**
      *
      * @tparam ArgsT Template Arguments for the event (Metadata) todo: figure out what this means
@@ -213,7 +213,7 @@ public:
         }
         return Results;
     }
-    std::set<std::string> GetEventHandlersForState(const std::string& EventName, TLuaStateId StateId);
+    std::vector<sol::basic_object<sol::basic_reference<>>> GetEventHandlersForState(const std::string& EventName, TLuaStateId StateId);
     void CreateEventTimer(const std::string& EventName, TLuaStateId StateId, size_t IntervalMS, CallStrategy Strategy);
     void CancelEventTimers(const std::string& EventName, TLuaStateId StateId);
     sol::state_view GetStateForPlugin(const fs::path& PluginPath);
@@ -226,7 +226,7 @@ public:
     std::vector<std::string> GetStateTableKeysForState(TLuaStateId StateId, std::vector<std::string> keys);
 
     // Debugging functions (slow)
-    std::unordered_map<std::string /*event name */, std::vector<std::string> /* handlers */> Debug_GetEventsForState(TLuaStateId StateId);
+    std::unordered_map<std::string /*event name */, std::vector<sol::object> /* handlers */> Debug_GetEventsForState(TLuaStateId StateId);
     std::queue<std::pair<TLuaChunk, std::shared_ptr<TLuaResult>>> Debug_GetStateExecuteQueueForState(TLuaStateId StateId);
     std::vector<QueuedFunction> Debug_GetStateFunctionQueueForState(TLuaStateId StateId);
     std::vector<TLuaResult> Debug_GetResultsToCheckForState(TLuaStateId StateId);
@@ -243,9 +243,9 @@ private:
         StateThreadData(const StateThreadData&) = delete;
         virtual ~StateThreadData() noexcept { beammp_debug("\"" + mStateId + "\" destroyed"); }
         [[nodiscard]] std::shared_ptr<TLuaResult> EnqueueScript(const TLuaChunk& Script);
-        [[nodiscard]] std::shared_ptr<TLuaResult> EnqueueFunctionCall(const std::string& FunctionName, const std::vector<TLuaValue>& Args, const std::string& EventName);
-        [[nodiscard]] std::shared_ptr<TLuaResult> EnqueueFunctionCallFromCustomEvent(const std::string& FunctionName, const std::vector<TLuaValue>& Args, const std::string& EventName, CallStrategy Strategy);
-        void RegisterEvent(const std::string& EventName, const std::string& FunctionName);
+        [[nodiscard]] std::shared_ptr<TLuaResult> EnqueueFunctionCall(const sol::object& FunctionObject, const std::vector<TLuaValue>& Args, const std::string& EventName);
+        [[nodiscard]] std::shared_ptr<TLuaResult> EnqueueFunctionCallFromCustomEvent(const sol::object& FunctionObject, const std::vector<TLuaValue>& Args, const std::string& EventName, CallStrategy Strategy);
+        void RegisterEvent(const std::string& EventName, const sol::object& FunctionObject) const;
         void AddPath(const fs::path& Path); // to be added to path and cpath
         void operator()() override;
         sol::state_view State() { return sol::state_view(mState); }
@@ -309,7 +309,7 @@ private:
     std::vector<std::shared_ptr<TLuaPlugin>> mLuaPlugins;
     std::unordered_map<TLuaStateId, std::unique_ptr<StateThreadData>> mLuaStates;
     std::recursive_mutex mLuaStatesMutex;
-    std::unordered_map<std::string /* event name */, std::unordered_map<TLuaStateId, std::set<std::string>>> mLuaEvents;
+    std::unordered_map<std::string /* event name */, std::unordered_map<TLuaStateId, std::vector<sol::object>>> mLuaEvents;
     std::recursive_mutex mLuaEventsMutex;
     std::vector<TimedEvent> mTimedEvents;
     std::recursive_mutex mTimedEventsMutex;

--- a/include/TLuaEngine.h
+++ b/include/TLuaEngine.h
@@ -214,7 +214,7 @@ public:
         }
         return Results;
     }
-    std::vector<std::variant<std::shared_ptr<sol::basic_protected_function<sol::basic_reference<true>>>, std::string>> GetEventHandlersForState(const std::string& EventName, TLuaStateId StateId);
+    std::set<std::variant<std::shared_ptr<sol::basic_protected_function<sol::basic_reference<true>>>, std::string>> GetEventHandlersForState(const std::string& EventName, TLuaStateId StateId);
     void CreateEventTimer(const std::string& EventName, TLuaStateId StateId, size_t IntervalMS, CallStrategy Strategy);
     void CancelEventTimers(const std::string& EventName, TLuaStateId StateId);
     sol::state_view GetStateForPlugin(const fs::path& PluginPath);
@@ -311,7 +311,7 @@ private:
     std::vector<std::shared_ptr<TLuaPlugin>> mLuaPlugins;
     std::unordered_map<TLuaStateId, std::unique_ptr<StateThreadData>> mLuaStates;
     std::recursive_mutex mLuaStatesMutex;
-    std::unordered_map<std::string, std::unordered_map<TLuaStateId, std::vector<LuaFunction>>> mLuaEvents;
+    std::unordered_map<std::string, std::unordered_map<TLuaStateId, std::set<LuaFunction>>> mLuaEvents;
     std::recursive_mutex mLuaEventsMutex;
     std::vector<TimedEvent> mTimedEvents;
     std::recursive_mutex mTimedEventsMutex;

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -35,6 +35,8 @@
 #include "CustomAssert.h"
 #include "Http.h"
 
+#include <sol/forward.hpp>
+
 void Application::RegisterShutdownHandler(const TShutdownHandler& Handler) {
     std::unique_lock Lock(mShutdownHandlersMutex);
     if (Handler) {
@@ -454,4 +456,11 @@ std::vector<uint8_t> Comp(std::span<const uint8_t> input) {
     beammp_debug("zlib compressed " + std::to_string(input.size()) + " B to " + std::to_string(output_size) + " B");
     output.resize(output_size);
     return output;
+}
+
+std::string GetFunctionName(const LuaFunction& cb) {
+    if (const std::string* name = std::get_if<std::string>(&cb)) {
+        return *name;
+    }
+    return "anonymous";
 }

--- a/src/LuaAPI.cpp
+++ b/src/LuaAPI.cpp
@@ -436,9 +436,10 @@ void LuaAPI::MP::PrintRaw(sol::variadic_args Args) {
 }
 
 int LuaAPI::PanicHandler(lua_State* State) {
-    const char* message = lua_tostring(State, -1);
+    std::optional<std::string> message = sol::stack::get<std::optional<std::string>>(State, -1);
+
     if (message) {
-        beammp_lua_error("PANIC: " + std::string(message));
+        beammp_lua_error("PANIC: " + *message);
     }
     return 0;
 }

--- a/src/LuaAPI.cpp
+++ b/src/LuaAPI.cpp
@@ -436,7 +436,10 @@ void LuaAPI::MP::PrintRaw(sol::variadic_args Args) {
 }
 
 int LuaAPI::PanicHandler(lua_State* State) {
-    beammp_lua_error("PANIC: " + sol::stack::get<std::string>(State, 1));
+    const char* message = lua_tostring(State, -1);
+    if (message) {
+        beammp_lua_error("PANIC: " + std::string(message));
+    }
     return 0;
 }
 

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -741,19 +741,19 @@ void TConsole::HandleLuaInternalCommand(const std::string& cmd) {
         int Index = 0;
         for (const LuaFunction Function : FunctionsInOrder) {
             if (!(std::find(Uniques.begin(), Uniques.end(), Function) == Uniques.end())) {
-                std::string functionName = GetFunctionName(Function);
+                std::string FunctionName = GetFunctionName(Function);
                 Uniques.push_back(Function);
                 if (Index != 0) {
-                    Application::Console().WriteRaw("    " + functionName + " (" + std::to_string(Index) + "x)");
+                    Application::Console().WriteRaw("    " + FunctionName + " (" + std::to_string(Index) + "x)");
                 } else {
-                    Application::Console().WriteRaw("    " + functionName);
+                    Application::Console().WriteRaw("    " + FunctionName);
                 }
             }
         }
         Application::Console().WriteRaw("Executed functions waiting to be checked in State '" + mStateId + "'");
         for (const auto& Function : LuaAPI::MP::Engine->Debug_GetResultsToCheckForState(mStateId)) {
-            std::string functionName = GetFunctionName(Function.Function);;
-            Application::Console().WriteRaw("    '" + functionName + "' (Ready? " + (Function.Ready ? "Yes" : "No") + ", Error? " + (Function.Error ? "Yes: '" + Function.ErrorMessage + "'" : "No") + ")");
+            std::string FunctionName = GetFunctionName(Function.Function);;
+            Application::Console().WriteRaw("    '" + FunctionName + "' (Ready? " + (Function.Ready ? "Yes" : "No") + ", Error? " + (Function.Error ? "Yes: '" + Function.ErrorMessage + "'" : "No") + ")");
         }
     } else if (cmd == "events") {
         auto Events = LuaAPI::MP::Engine->Debug_GetEventsForState(mStateId);
@@ -761,8 +761,8 @@ void TConsole::HandleLuaInternalCommand(const std::string& cmd) {
         for (const auto& EventHandlerPair : Events) {
             Application::Console().WriteRaw("    Event '" + EventHandlerPair.first + "'");
             for (const auto& Handler : EventHandlerPair.second) {
-                std::string functionName = GetFunctionName(Handler);;
-                Application::Console().WriteRaw("        " + functionName);
+                std::string FunctionName = GetFunctionName(Handler);;
+                Application::Console().WriteRaw("        " + FunctionName);
             }
         }
     } else if (cmd == "help") {

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -732,28 +732,26 @@ void TConsole::HandleLuaInternalCommand(const std::string& cmd) {
     } else if (cmd == "queued") {
         auto QueuedFunctions = LuaAPI::MP::Engine->Debug_GetStateFunctionQueueForState(mStateId);
         Application::Console().WriteRaw("Pending functions in State '" + mStateId + "'");
-        std::unordered_map<std::string, size_t> FunctionsCount;
-        std::vector<std::string> FunctionsInOrder;
-        while (!QueuedFunctions.empty()) {
-            auto Tuple = QueuedFunctions.front();
-            QueuedFunctions.erase(QueuedFunctions.begin());
-            FunctionsInOrder.push_back(Tuple.FunctionName);
-            FunctionsCount[Tuple.FunctionName] += 1;
+        size_t FunctionsCount = QueuedFunctions.size();
+        std::vector<sol::object> FunctionsInOrder;
+        for (int i = 0; i < FunctionsCount; ++i) {
+            FunctionsInOrder.push_back(QueuedFunctions[i].FunctionObject);
         }
-        std::set<std::string> Uniques;
-        for (const auto& Function : FunctionsInOrder) {
-            if (Uniques.count(Function) == 0) {
-                Uniques.insert(Function);
-                if (FunctionsCount.at(Function) > 1) {
-                    Application::Console().WriteRaw("    " + Function + " (" + std::to_string(FunctionsCount.at(Function)) + "x)");
+        std::vector<sol::object> Uniques;
+        int Index = 0;
+        for (const sol::object Function : FunctionsInOrder) {
+            if (!(std::find(Uniques.begin(), Uniques.end(), Function) == Uniques.end())) {
+                Uniques.push_back(Function);
+                if (Index != 0) {
+                    Application::Console().WriteRaw("    " + Function.as<std::string>() + " (" + std::to_string(Index) + "x)");
                 } else {
-                    Application::Console().WriteRaw("    " + Function);
+                    Application::Console().WriteRaw("    " + Function.as<std::string>());
                 }
             }
         }
         Application::Console().WriteRaw("Executed functions waiting to be checked in State '" + mStateId + "'");
         for (const auto& Function : LuaAPI::MP::Engine->Debug_GetResultsToCheckForState(mStateId)) {
-            Application::Console().WriteRaw("    '" + Function.Function + "' (Ready? " + (Function.Ready ? "Yes" : "No") + ", Error? " + (Function.Error ? "Yes: '" + Function.ErrorMessage + "'" : "No") + ")");
+            Application::Console().WriteRaw("    '" + Function.Function.as<std::string>() + "' (Ready? " + (Function.Ready ? "Yes" : "No") + ", Error? " + (Function.Error ? "Yes: '" + Function.ErrorMessage + "'" : "No") + ")");
         }
     } else if (cmd == "events") {
         auto Events = LuaAPI::MP::Engine->Debug_GetEventsForState(mStateId);
@@ -761,7 +759,7 @@ void TConsole::HandleLuaInternalCommand(const std::string& cmd) {
         for (const auto& EventHandlerPair : Events) {
             Application::Console().WriteRaw("    Event '" + EventHandlerPair.first + "'");
             for (const auto& Handler : EventHandlerPair.second) {
-                Application::Console().WriteRaw("        " + Handler);
+                Application::Console().WriteRaw("        " + Handler.as<std::string>());
             }
         }
     } else if (cmd == "help") {

--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -733,25 +733,27 @@ void TConsole::HandleLuaInternalCommand(const std::string& cmd) {
         auto QueuedFunctions = LuaAPI::MP::Engine->Debug_GetStateFunctionQueueForState(mStateId);
         Application::Console().WriteRaw("Pending functions in State '" + mStateId + "'");
         size_t FunctionsCount = QueuedFunctions.size();
-        std::vector<sol::object> FunctionsInOrder;
+        std::vector<LuaFunction> FunctionsInOrder;
         for (int i = 0; i < FunctionsCount; ++i) {
             FunctionsInOrder.push_back(QueuedFunctions[i].FunctionObject);
         }
-        std::vector<sol::object> Uniques;
+        std::vector<LuaFunction> Uniques;
         int Index = 0;
-        for (const sol::object Function : FunctionsInOrder) {
+        for (const LuaFunction Function : FunctionsInOrder) {
             if (!(std::find(Uniques.begin(), Uniques.end(), Function) == Uniques.end())) {
+                std::string functionName = GetFunctionName(Function);
                 Uniques.push_back(Function);
                 if (Index != 0) {
-                    Application::Console().WriteRaw("    " + Function.as<std::string>() + " (" + std::to_string(Index) + "x)");
+                    Application::Console().WriteRaw("    " + functionName + " (" + std::to_string(Index) + "x)");
                 } else {
-                    Application::Console().WriteRaw("    " + Function.as<std::string>());
+                    Application::Console().WriteRaw("    " + functionName);
                 }
             }
         }
         Application::Console().WriteRaw("Executed functions waiting to be checked in State '" + mStateId + "'");
         for (const auto& Function : LuaAPI::MP::Engine->Debug_GetResultsToCheckForState(mStateId)) {
-            Application::Console().WriteRaw("    '" + Function.Function.as<std::string>() + "' (Ready? " + (Function.Ready ? "Yes" : "No") + ", Error? " + (Function.Error ? "Yes: '" + Function.ErrorMessage + "'" : "No") + ")");
+            std::string functionName = GetFunctionName(Function.Function);;
+            Application::Console().WriteRaw("    '" + functionName + "' (Ready? " + (Function.Ready ? "Yes" : "No") + ", Error? " + (Function.Error ? "Yes: '" + Function.ErrorMessage + "'" : "No") + ")");
         }
     } else if (cmd == "events") {
         auto Events = LuaAPI::MP::Engine->Debug_GetEventsForState(mStateId);
@@ -759,7 +761,8 @@ void TConsole::HandleLuaInternalCommand(const std::string& cmd) {
         for (const auto& EventHandlerPair : Events) {
             Application::Console().WriteRaw("    Event '" + EventHandlerPair.first + "'");
             for (const auto& Handler : EventHandlerPair.second) {
-                Application::Console().WriteRaw("        " + Handler.as<std::string>());
+                std::string functionName = GetFunctionName(Handler);;
+                Application::Console().WriteRaw("        " + functionName);
             }
         }
     } else if (cmd == "help") {

--- a/src/TLuaEngine.cpp
+++ b/src/TLuaEngine.cpp
@@ -207,10 +207,9 @@ std::queue<std::pair<TLuaChunk, std::shared_ptr<TLuaResult>>> TLuaEngine::Debug_
     return Result;
 }
 
-std::vector<TLuaEngine::QueuedFunction> TLuaEngine::Debug_GetStateFunctionQueueForState(TLuaStateId StateId) {
-    std::vector<TLuaEngine::QueuedFunction> Result;
+std::deque<TLuaEngine::QueuedFunction> TLuaEngine::Debug_GetStateFunctionQueueForState(TLuaStateId StateId) {
     std::unique_lock Lock(mLuaStatesMutex);
-    Result = mLuaStates.at(StateId)->Debug_GetStateFunctionQueue();
+    std::deque<TLuaEngine::QueuedFunction> Result = mLuaStates.at(StateId)->Debug_GetStateFunctionQueue();
     return Result;
 }
 
@@ -433,7 +432,7 @@ void TLuaEngine::EnsureStateExists(TLuaStateId StateId, const std::string& Name,
 
 void TLuaEngine::RegisterEvent(const std::string& EventName, TLuaStateId StateId, const sol::object& FunctionObject) {
     std::unique_lock Lock(mLuaEventsMutex);
-    mLuaEvents[EventName][StateId].emplace_back(FunctionObject);
+    mLuaEvents[EventName][StateId] = { FunctionObject };
 }
 
 std::vector<sol::basic_object<sol::basic_reference<>>> TLuaEngine::GetEventHandlersForState(const std::string& EventName, TLuaStateId StateId) {
@@ -1044,8 +1043,9 @@ std::shared_ptr<TLuaResult> TLuaEngine::StateThreadData::EnqueueScript(const TLu
 }
 
 std::shared_ptr<TLuaResult> TLuaEngine::StateThreadData::EnqueueFunctionCallFromCustomEvent(const sol::object& FunctionObject, const std::vector<TLuaValue>& Args, const std::string& EventName, CallStrategy Strategy) {
+    std::unique_lock Lock(mStateFunctionQueueMutex);
+    auto Iter = mStateFunctionQueue.end();
     // TODO: Document all this
-    decltype(mStateFunctionQueue)::iterator Iter = mStateFunctionQueue.end();
     if (Strategy == CallStrategy::BestEffort) {
         Iter = std::find_if(mStateFunctionQueue.begin(), mStateFunctionQueue.end(),
             [&EventName](const QueuedFunction& Element) {
@@ -1056,13 +1056,11 @@ std::shared_ptr<TLuaResult> TLuaEngine::StateThreadData::EnqueueFunctionCallFrom
         auto Result = std::make_shared<TLuaResult>();
         Result->StateId = mStateId;
         Result->Function = FunctionObject;
-        std::unique_lock Lock(mStateFunctionQueueMutex);
         mStateFunctionQueue.push_back({ FunctionObject, Result, Args, EventName });
         mStateFunctionQueueCond.notify_all();
         return Result;
-    } else {
-        return nullptr;
     }
+    return nullptr;
 }
 
 std::shared_ptr<TLuaResult> TLuaEngine::StateThreadData::EnqueueFunctionCall(const sol::object& FunctionObject, const std::vector<TLuaValue>& Args, const std::string& EventName) {
@@ -1135,7 +1133,7 @@ void TLuaEngine::StateThreadData::operator()() {
             if (NotExpired) {
                 auto ProfStart = prof::now();
                 auto TheQueuedFunction = std::move(mStateFunctionQueue.front());
-                mStateFunctionQueue.erase(mStateFunctionQueue.begin());
+                mStateFunctionQueue.pop_front();
                 Lock.unlock();
                 auto& Result = TheQueuedFunction.Result;
                 auto Args = TheQueuedFunction.Args;
@@ -1218,9 +1216,9 @@ std::queue<std::pair<TLuaChunk, std::shared_ptr<TLuaResult>>> TLuaEngine::StateT
     return mStateExecuteQueue;
 }
 
-std::vector<TLuaEngine::QueuedFunction> TLuaEngine::StateThreadData::Debug_GetStateFunctionQueue() {
+std::deque<TLuaEngine::QueuedFunction> TLuaEngine::StateThreadData::Debug_GetStateFunctionQueue() {
     std::unique_lock Lock(mStateFunctionQueueMutex);
-    return mStateFunctionQueue;
+    return std::deque<TLuaEngine::QueuedFunction>(mStateFunctionQueue);
 }
 
 void TLuaEngine::CreateEventTimer(const std::string& EventName, TLuaStateId StateId, size_t IntervalMS, CallStrategy Strategy) {
@@ -1232,6 +1230,10 @@ void TLuaEngine::CreateEventTimer(const std::string& EventName, TLuaStateId Stat
         StateId,
         Strategy
     };
+    if (std::ranges::any_of(mTimedEvents, [&](const auto& e) { return e.EventName == Event.EventName && e.StateId == Event.StateId; })) {
+        beammp_trace("event timer for \"" + EventName + "\" on \"" + StateId + "\" already exists");
+        return;
+    }
     mTimedEvents.push_back(std::move(Event));
     beammp_trace("created event timer for \"" + EventName + "\" on \"" + StateId + "\" with " + std::to_string(IntervalMS) + "ms interval");
 }

--- a/src/TLuaEngine.cpp
+++ b/src/TLuaEngine.cpp
@@ -1092,7 +1092,7 @@ void TLuaEngine::StateThreadData::operator()() {
                 Lock.unlock();
 
                 { // Paths Scope
-                    std::unique_lock Lock(mPathsMutex);
+                    std::unique_lock PathLock(mPathsMutex);
                     if (!mPaths.empty()) {
                         std::stringstream PathAdditions;
                         std::stringstream CPathAdditions;

--- a/src/TLuaEngine.cpp
+++ b/src/TLuaEngine.cpp
@@ -1174,11 +1174,9 @@ void TLuaEngine::StateThreadData::operator()() {
                         S->second->Result = std::move(Res);
                     }
                 } else {
-                    if (lua_gettop(mState) > 0) {
-                        if (sol::stack_object err_obj(mState, -1); err_obj.is<std::string>()) {
-                            S->second->ErrorMessage = err_obj.as<std::string>();
-                        }
-                    }
+                    S->second->Error = true;
+                    sol::error err = Res;
+                    S->second->ErrorMessage = err.what();
                 }
                 lua_settop(mState, 0);
                 S->second->MarkAsReady();

--- a/src/TLuaEngine.cpp
+++ b/src/TLuaEngine.cpp
@@ -330,29 +330,29 @@ void TLuaEngine::WaitForAll(std::vector<std::shared_ptr<TLuaResult>>& Results, c
         bool Cancelled = false;
         size_t ms = 0;
         std::set<std::string> WarnedResults;
-        std::string functionName = GetFunctionName(Result->Function);
+        std::string FunctionName = GetFunctionName(Result->Function);
 
         while (!Result->Ready && !Cancelled) {
             std::this_thread::sleep_for(std::chrono::milliseconds(10));
             ms += 10;
             if (Max.has_value() && std::chrono::milliseconds(ms) > Max.value()) {
-                beammp_trace("'" + functionName + "' in '" + Result->StateId + "' did not finish executing in time (took: " + std::to_string(ms) + "ms).");
+                beammp_trace("'" + FunctionName + "' in '" + Result->StateId + "' did not finish executing in time (took: " + std::to_string(ms) + "ms).");
                 Cancelled = true;
             } else if (ms > 1000 * 60) {
-                auto ResultId = Result->StateId + "_" + functionName;
+                auto ResultId = Result->StateId + "_" + FunctionName;
                 if (WarnedResults.count(ResultId) == 0) {
                     WarnedResults.insert(ResultId);
-                    beammp_lua_warn("'" + functionName + "' in '" + Result->StateId + "' is taking very long. The event it's handling is too important to discard the result of this handler, but may block this event and possibly the whole lua state.");
+                    beammp_lua_warn("'" + FunctionName + "' in '" + Result->StateId + "' is taking very long. The event it's handling is too important to discard the result of this handler, but may block this event and possibly the whole lua state.");
                 }
             }
         }
 
         if (Cancelled) {
-            beammp_lua_warn("'" + functionName + "' in '" + Result->StateId + "' failed to execute in time and was not waited for. It may still finish executing at a later time.");
+            beammp_lua_warn("'" + FunctionName + "' in '" + Result->StateId + "' failed to execute in time and was not waited for. It may still finish executing at a later time.");
             LuaAPI::MP::Engine->ReportErrors({ Result });
         } else if (Result->Error) {
             if (Result->ErrorMessage != BeamMPFnNotFoundError) {
-                beammp_lua_error(functionName + ": " + Result->ErrorMessage);
+                beammp_lua_error(FunctionName + ": " + Result->ErrorMessage);
             }
         }
     }

--- a/src/TLuaEngine.cpp
+++ b/src/TLuaEngine.cpp
@@ -87,7 +87,7 @@ void TLuaEngine::operator()() {
                     if (Ptr->Ready) {
                         if (Ptr->Error) {
                             if (Ptr->ErrorMessage != BeamMPFnNotFoundError) {
-                                beammp_lua_error(Ptr->Function + ": " + Ptr->ErrorMessage);
+                                beammp_lua_error(Ptr->Function.as<std::string>() + ": " + Ptr->ErrorMessage);
                             }
                         }
                         return true;
@@ -185,8 +185,8 @@ void TLuaEngine::AddResultToCheck(const std::shared_ptr<TLuaResult>& Result) {
     mResultsToCheckCond.notify_one();
 }
 
-std::unordered_map<std::string /* event name */, std::vector<std::string> /* handlers */> TLuaEngine::Debug_GetEventsForState(TLuaStateId StateId) {
-    std::unordered_map<std::string, std::vector<std::string>> Result;
+std::unordered_map<std::string /* event name */, std::vector<sol::object> /* handlers */> TLuaEngine::Debug_GetEventsForState(TLuaStateId StateId) {
+    std::unordered_map<std::string, std::vector<sol::object>> Result;
     std::unique_lock Lock(mLuaEventsMutex);
     for (const auto& EventNameToEventMap : mLuaEvents) {
         for (const auto& IdSetOfHandlersPair : EventNameToEventMap.second) {
@@ -314,23 +314,23 @@ void TLuaEngine::WaitForAll(std::vector<std::shared_ptr<TLuaResult>>& Results, c
             std::this_thread::sleep_for(std::chrono::milliseconds(10));
             ms += 10;
             if (Max.has_value() && std::chrono::milliseconds(ms) > Max.value()) {
-                beammp_trace("'" + Result->Function + "' in '" + Result->StateId + "' did not finish executing in time (took: " + std::to_string(ms) + "ms).");
+                beammp_trace("'" + Result->Function.as<std::string>() + "' in '" + Result->StateId + "' did not finish executing in time (took: " + std::to_string(ms) + "ms).");
                 Cancelled = true;
             } else if (ms > 1000 * 60) {
-                auto ResultId = Result->StateId + "_" + Result->Function;
+                auto ResultId = Result->StateId + "_" + Result->Function.as<std::string>();
                 if (WarnedResults.count(ResultId) == 0) {
                     WarnedResults.insert(ResultId);
-                    beammp_lua_warn("'" + Result->Function + "' in '" + Result->StateId + "' is taking very long. The event it's handling is too important to discard the result of this handler, but may block this event and possibly the whole lua state.");
+                    beammp_lua_warn("'" + Result->Function.as<std::string>() + "' in '" + Result->StateId + "' is taking very long. The event it's handling is too important to discard the result of this handler, but may block this event and possibly the whole lua state.");
                 }
             }
         }
 
         if (Cancelled) {
-            beammp_lua_warn("'" + Result->Function + "' in '" + Result->StateId + "' failed to execute in time and was not waited for. It may still finish executing at a later time.");
+            beammp_lua_warn("'" + Result->Function.as<std::string>() + "' in '" + Result->StateId + "' failed to execute in time and was not waited for. It may still finish executing at a later time.");
             LuaAPI::MP::Engine->ReportErrors({ Result });
         } else if (Result->Error) {
             if (Result->ErrorMessage != BeamMPFnNotFoundError) {
-                beammp_lua_error(Result->Function + ": " + Result->ErrorMessage);
+                beammp_lua_error(Result->Function.as<std::string>() + ": " + Result->ErrorMessage);
             }
         }
     }
@@ -355,9 +355,9 @@ std::shared_ptr<TLuaResult> TLuaEngine::EnqueueScript(TLuaStateId StateID, const
     return mLuaStates.at(StateID)->EnqueueScript(Script);
 }
 
-std::shared_ptr<TLuaResult> TLuaEngine::EnqueueFunctionCall(TLuaStateId StateID, const std::string& FunctionName, const std::vector<TLuaValue>& Args, const std::string& EventName) {
+std::shared_ptr<TLuaResult> TLuaEngine::EnqueueFunctionCall(TLuaStateId StateID, const sol::object& FunctionObject, const std::vector<TLuaValue>& Args, const std::string& EventName) {
     std::unique_lock Lock(mLuaStatesMutex);
-    return mLuaStates.at(StateID)->EnqueueFunctionCall(FunctionName, Args, EventName);
+    return mLuaStates.at(StateID)->EnqueueFunctionCall(FunctionObject, Args, EventName);
 }
 
 void TLuaEngine::CollectAndInitPlugins() {
@@ -428,23 +428,15 @@ void TLuaEngine::EnsureStateExists(TLuaStateId StateId, const std::string& Name,
         beammp_debug("Creating lua state for state id \"" + StateId + "\"");
         auto DataPtr = std::make_unique<StateThreadData>(Name, StateId, *this);
         mLuaStates[StateId] = std::move(DataPtr);
-        RegisterEvent("onInit", StateId, "onInit");
-        if (!DontCallOnInit) {
-            auto Res = EnqueueFunctionCall(StateId, "onInit", {}, "onInit");
-            Res->WaitUntilReady();
-            if (Res->Error && Res->ErrorMessage != TLuaEngine::BeamMPFnNotFoundError) {
-                beammp_lua_error("Calling \"onInit\" on \"" + StateId + "\" failed: " + Res->ErrorMessage);
-            }
-        }
     }
 }
 
-void TLuaEngine::RegisterEvent(const std::string& EventName, TLuaStateId StateId, const std::string& FunctionName) {
+void TLuaEngine::RegisterEvent(const std::string& EventName, TLuaStateId StateId, const sol::object& FunctionObject) {
     std::unique_lock Lock(mLuaEventsMutex);
-    mLuaEvents[EventName][StateId].insert(FunctionName);
+    mLuaEvents[EventName][StateId].emplace_back(FunctionObject);
 }
 
-std::set<std::string> TLuaEngine::GetEventHandlersForState(const std::string& EventName, TLuaStateId StateId) {
+std::vector<sol::basic_object<sol::basic_reference<>>> TLuaEngine::GetEventHandlersForState(const std::string& EventName, TLuaStateId StateId) {
     return mLuaEvents[EventName][StateId];
 }
 
@@ -542,7 +534,12 @@ sol::table TLuaEngine::StateThreadData::Lua_TriggerLocalEvent(const std::string&
     sol::table Result = mStateView.create_table();
     int i = 1;
     for (const auto& Handler : mEngine->GetEventHandlersForState(EventName, mStateId)) {
-        auto Fn = mStateView[Handler];
+        auto Fn = sol::function();
+        if (Handler.is<std::string>()) {
+            Fn = mStateView[Handler];
+        }else {
+            Fn = Handler;
+        }
         if (Fn.valid() && Fn.get_type() == sol::type::function) {
             auto FnRet = Fn(EventArgs);
             if (FnRet.valid()) {
@@ -831,8 +828,8 @@ TLuaEngine::StateThreadData::StateThreadData(const std::string& Name, TLuaStateI
     });
     MPTable.set_function("GetOSName", &LuaAPI::MP::GetOSName);
     MPTable.set_function("GetServerVersion", &LuaAPI::MP::GetServerVersion);
-    MPTable.set_function("RegisterEvent", [this](const std::string& EventName, const std::string& FunctionName) {
-        RegisterEvent(EventName, FunctionName);
+    MPTable.set_function("RegisterEvent", [this](const std::string& EventName, const sol::object& FunctionObject) {
+        RegisterEvent(EventName, FunctionObject);
     });
     MPTable.set_function("TriggerGlobalEvent", [&](const std::string& EventName, sol::variadic_args EventArgs) -> sol::table {
         return Lua_TriggerGlobalEvent(EventName, EventArgs);
@@ -1046,7 +1043,7 @@ std::shared_ptr<TLuaResult> TLuaEngine::StateThreadData::EnqueueScript(const TLu
     return Result;
 }
 
-std::shared_ptr<TLuaResult> TLuaEngine::StateThreadData::EnqueueFunctionCallFromCustomEvent(const std::string& FunctionName, const std::vector<TLuaValue>& Args, const std::string& EventName, CallStrategy Strategy) {
+std::shared_ptr<TLuaResult> TLuaEngine::StateThreadData::EnqueueFunctionCallFromCustomEvent(const sol::object& FunctionObject, const std::vector<TLuaValue>& Args, const std::string& EventName, CallStrategy Strategy) {
     // TODO: Document all this
     decltype(mStateFunctionQueue)::iterator Iter = mStateFunctionQueue.end();
     if (Strategy == CallStrategy::BestEffort) {
@@ -1058,9 +1055,9 @@ std::shared_ptr<TLuaResult> TLuaEngine::StateThreadData::EnqueueFunctionCallFrom
     if (Iter == mStateFunctionQueue.end()) {
         auto Result = std::make_shared<TLuaResult>();
         Result->StateId = mStateId;
-        Result->Function = FunctionName;
+        Result->Function = FunctionObject;
         std::unique_lock Lock(mStateFunctionQueueMutex);
-        mStateFunctionQueue.push_back({ FunctionName, Result, Args, EventName });
+        mStateFunctionQueue.push_back({ FunctionObject, Result, Args, EventName });
         mStateFunctionQueueCond.notify_all();
         return Result;
     } else {
@@ -1068,18 +1065,18 @@ std::shared_ptr<TLuaResult> TLuaEngine::StateThreadData::EnqueueFunctionCallFrom
     }
 }
 
-std::shared_ptr<TLuaResult> TLuaEngine::StateThreadData::EnqueueFunctionCall(const std::string& FunctionName, const std::vector<TLuaValue>& Args, const std::string& EventName) {
+std::shared_ptr<TLuaResult> TLuaEngine::StateThreadData::EnqueueFunctionCall(const sol::object& FunctionObject, const std::vector<TLuaValue>& Args, const std::string& EventName) {
     auto Result = std::make_shared<TLuaResult>();
     Result->StateId = mStateId;
-    Result->Function = FunctionName;
+    Result->Function = FunctionObject;
     std::unique_lock Lock(mStateFunctionQueueMutex);
-    mStateFunctionQueue.push_back({ FunctionName, Result, Args, EventName });
+    mStateFunctionQueue.push_back({ FunctionObject, Result, Args, EventName });
     mStateFunctionQueueCond.notify_all();
     return Result;
 }
 
-void TLuaEngine::StateThreadData::RegisterEvent(const std::string& EventName, const std::string& FunctionName) {
-    mEngine->RegisterEvent(EventName, mStateId, FunctionName);
+void TLuaEngine::StateThreadData::RegisterEvent(const std::string& EventName, const sol::object& FunctionObject) const {
+    mEngine->RegisterEvent(EventName, mStateId, FunctionObject);
 }
 
 void TLuaEngine::StateThreadData::operator()() {
@@ -1140,13 +1137,18 @@ void TLuaEngine::StateThreadData::operator()() {
                 auto TheQueuedFunction = std::move(mStateFunctionQueue.front());
                 mStateFunctionQueue.erase(mStateFunctionQueue.begin());
                 Lock.unlock();
-                auto& FnName = TheQueuedFunction.FunctionName;
                 auto& Result = TheQueuedFunction.Result;
                 auto Args = TheQueuedFunction.Args;
                 // TODO: Use TheQueuedFunction.EventName for errors, warnings, etc
                 Result->StateId = mStateId;
                 sol::state_view StateView(mState);
-                auto Fn = StateView[FnName];
+
+                auto Fn = sol::function();
+                if (TheQueuedFunction.FunctionObject.is<std::string>()) {
+                        Fn = StateView[TheQueuedFunction.FunctionObject];
+                }else {
+                        Fn = TheQueuedFunction.FunctionObject;
+                }
                 if (Fn.valid() && Fn.get_type() == sol::type::function) {
                     std::vector<sol::object> LuaArgs;
                     for (const auto& Arg : Args) {
@@ -1199,7 +1201,13 @@ void TLuaEngine::StateThreadData::operator()() {
                 }
                 auto ProfEnd = prof::now();
                 auto ProfDuration = prof::duration(ProfStart, ProfEnd);
-                mProfile.add_sample(FnName, ProfDuration);
+                std::string profileName;
+                if (TheQueuedFunction.FunctionObject.is<std::string>()) {
+                    profileName = TheQueuedFunction.FunctionObject.as<std::string>();
+                } else {
+                    profileName = "[lua anonymous function]";
+                }
+                mProfile.add_sample(profileName, ProfDuration);
             }
         }
     }

--- a/src/TLuaEngine.cpp
+++ b/src/TLuaEngine.cpp
@@ -457,11 +457,11 @@ void TLuaEngine::RegisterEvent(const std::string& EventName, TLuaStateId StateId
     std::unique_lock Lock(mLuaEventsMutex);
     auto& Events = mLuaEvents[EventName][StateId];
     if (const auto it = std::find(Events.begin(), Events.end(), FunctionObject); it == Events.end()) {
-        Events.push_back(std::move(FunctionObject));
+        Events.emplace(std::move(FunctionObject));
     }
 }
 
-std::vector<std::variant<std::shared_ptr<sol::basic_protected_function<sol::basic_reference<true>>>, std::string>> TLuaEngine::GetEventHandlersForState(const std::string& EventName, TLuaStateId StateId) {
+std::set<std::variant<std::shared_ptr<sol::basic_protected_function<sol::basic_reference<true>>>, std::string>> TLuaEngine::GetEventHandlersForState(const std::string& EventName, TLuaStateId StateId) {
     return mLuaEvents[EventName][StateId];
 }
 

--- a/src/TLuaEngine.cpp
+++ b/src/TLuaEngine.cpp
@@ -87,7 +87,7 @@ void TLuaEngine::operator()() {
                     if (Ptr->Ready) {
                         if (Ptr->Error) {
                             if (Ptr->ErrorMessage != BeamMPFnNotFoundError) {
-                                beammp_lua_error(Ptr->Function.as<std::string>() + ": " + Ptr->ErrorMessage);
+                                beammp_lua_error(GetFunctionName(Ptr->Function) + ": " + Ptr->ErrorMessage);
                             }
                         }
                         return true;
@@ -104,15 +104,18 @@ void TLuaEngine::operator()() {
     while (!Application::IsShuttingDown()) {
         { // Timed Events Scope
             std::unique_lock Lock(mTimedEventsMutex);
+
             for (auto& Timer : mTimedEvents) {
                 if (Timer.Expired()) {
                     auto LastCompletionBeforeReset = Timer.LastCompletion;
                     Timer.Reset();
-                    auto Handlers = GetEventHandlersForState(Timer.EventName, Timer.StateId);
                     std::unique_lock StateLock(mLuaStatesMutex);
+                    auto& StateData = mLuaStates[Timer.StateId];
+
+                    auto Handlers = GetEventHandlersForState(Timer.EventName, Timer.StateId);
                     std::unique_lock Lock2(mResultsToCheckMutex);
                     for (auto& Handler : Handlers) {
-                        auto Res = mLuaStates[Timer.StateId]->EnqueueFunctionCallFromCustomEvent(Handler, {}, Timer.EventName, Timer.Strategy);
+                        auto Res = StateData->EnqueueFunctionCallFromCustomEvent(Handler, {}, Timer.EventName, Timer.Strategy);
                         if (Res) {
                             mResultsToCheck.push_back(Res);
                             mResultsToCheckCond.notify_one();
@@ -185,8 +188,8 @@ void TLuaEngine::AddResultToCheck(const std::shared_ptr<TLuaResult>& Result) {
     mResultsToCheckCond.notify_one();
 }
 
-std::unordered_map<std::string /* event name */, std::vector<sol::object> /* handlers */> TLuaEngine::Debug_GetEventsForState(TLuaStateId StateId) {
-    std::unordered_map<std::string, std::vector<sol::object>> Result;
+std::unordered_map<std::string /* event name */, std::vector<LuaFunction> /* handlers */> TLuaEngine::Debug_GetEventsForState(TLuaStateId StateId) {
+    std::unordered_map<std::string, std::vector<LuaFunction>> Result;
     std::unique_lock Lock(mLuaEventsMutex);
     for (const auto& EventNameToEventMap : mLuaEvents) {
         for (const auto& IdSetOfHandlersPair : EventNameToEventMap.second) {
@@ -308,28 +311,29 @@ void TLuaEngine::WaitForAll(std::vector<std::shared_ptr<TLuaResult>>& Results, c
         bool Cancelled = false;
         size_t ms = 0;
         std::set<std::string> WarnedResults;
+        std::string functionName = GetFunctionName(Result->Function);
 
         while (!Result->Ready && !Cancelled) {
             std::this_thread::sleep_for(std::chrono::milliseconds(10));
             ms += 10;
             if (Max.has_value() && std::chrono::milliseconds(ms) > Max.value()) {
-                beammp_trace("'" + Result->Function.as<std::string>() + "' in '" + Result->StateId + "' did not finish executing in time (took: " + std::to_string(ms) + "ms).");
+                beammp_trace("'" + functionName + "' in '" + Result->StateId + "' did not finish executing in time (took: " + std::to_string(ms) + "ms).");
                 Cancelled = true;
             } else if (ms > 1000 * 60) {
-                auto ResultId = Result->StateId + "_" + Result->Function.as<std::string>();
+                auto ResultId = Result->StateId + "_" + functionName;
                 if (WarnedResults.count(ResultId) == 0) {
                     WarnedResults.insert(ResultId);
-                    beammp_lua_warn("'" + Result->Function.as<std::string>() + "' in '" + Result->StateId + "' is taking very long. The event it's handling is too important to discard the result of this handler, but may block this event and possibly the whole lua state.");
+                    beammp_lua_warn("'" + functionName + "' in '" + Result->StateId + "' is taking very long. The event it's handling is too important to discard the result of this handler, but may block this event and possibly the whole lua state.");
                 }
             }
         }
 
         if (Cancelled) {
-            beammp_lua_warn("'" + Result->Function.as<std::string>() + "' in '" + Result->StateId + "' failed to execute in time and was not waited for. It may still finish executing at a later time.");
+            beammp_lua_warn("'" + functionName + "' in '" + Result->StateId + "' failed to execute in time and was not waited for. It may still finish executing at a later time.");
             LuaAPI::MP::Engine->ReportErrors({ Result });
         } else if (Result->Error) {
             if (Result->ErrorMessage != BeamMPFnNotFoundError) {
-                beammp_lua_error(Result->Function.as<std::string>() + ": " + Result->ErrorMessage);
+                beammp_lua_error(functionName + ": " + Result->ErrorMessage);
             }
         }
     }
@@ -354,7 +358,7 @@ std::shared_ptr<TLuaResult> TLuaEngine::EnqueueScript(TLuaStateId StateID, const
     return mLuaStates.at(StateID)->EnqueueScript(Script);
 }
 
-std::shared_ptr<TLuaResult> TLuaEngine::EnqueueFunctionCall(TLuaStateId StateID, const sol::object& FunctionObject, const std::vector<TLuaValue>& Args, const std::string& EventName) {
+std::shared_ptr<TLuaResult> TLuaEngine::EnqueueFunctionCall(TLuaStateId StateID, const LuaFunction& FunctionObject, const std::vector<TLuaValue>& Args, const std::string& EventName) {
     std::unique_lock Lock(mLuaStatesMutex);
     return mLuaStates.at(StateID)->EnqueueFunctionCall(FunctionObject, Args, EventName);
 }
@@ -430,12 +434,12 @@ void TLuaEngine::EnsureStateExists(TLuaStateId StateId, const std::string& Name,
     }
 }
 
-void TLuaEngine::RegisterEvent(const std::string& EventName, TLuaStateId StateId, const sol::object& FunctionObject) {
+void TLuaEngine::RegisterEvent(const std::string& EventName, TLuaStateId StateId, const LuaFunction& FunctionObject) {
     std::unique_lock Lock(mLuaEventsMutex);
-    mLuaEvents[EventName][StateId] = { FunctionObject };
+    mLuaEvents[EventName][StateId].push_back(std::move(FunctionObject));
 }
 
-std::vector<sol::basic_object<sol::basic_reference<>>> TLuaEngine::GetEventHandlersForState(const std::string& EventName, TLuaStateId StateId) {
+std::vector<std::variant<sol::basic_protected_function<sol::basic_reference<true>>, std::string>> TLuaEngine::GetEventHandlersForState(const std::string& EventName, TLuaStateId StateId) {
     return mLuaEvents[EventName][StateId];
 }
 
@@ -534,10 +538,10 @@ sol::table TLuaEngine::StateThreadData::Lua_TriggerLocalEvent(const std::string&
     int i = 1;
     for (const auto& Handler : mEngine->GetEventHandlersForState(EventName, mStateId)) {
         auto Fn = sol::function();
-        if (Handler.is<std::string>()) {
-            Fn = mStateView[Handler];
+        if (std::holds_alternative<std::string>(Handler)) {
+            Fn = mStateView[std::get<std::string>(Handler)];
         }else {
-            Fn = Handler;
+            Fn = std::get<sol::main_protected_function>(Handler);
         }
         if (Fn.valid() && Fn.get_type() == sol::type::function) {
             auto FnRet = Fn(EventArgs);
@@ -827,7 +831,7 @@ TLuaEngine::StateThreadData::StateThreadData(const std::string& Name, TLuaStateI
     });
     MPTable.set_function("GetOSName", &LuaAPI::MP::GetOSName);
     MPTable.set_function("GetServerVersion", &LuaAPI::MP::GetServerVersion);
-    MPTable.set_function("RegisterEvent", [this](const std::string& EventName, const sol::object& FunctionObject) {
+    MPTable.set_function("RegisterEvent", [this](const std::string& EventName, const sol::main_object& FunctionObject) {
         RegisterEvent(EventName, FunctionObject);
     });
     MPTable.set_function("TriggerGlobalEvent", [&](const std::string& EventName, sol::variadic_args EventArgs) -> sol::table {
@@ -1042,7 +1046,7 @@ std::shared_ptr<TLuaResult> TLuaEngine::StateThreadData::EnqueueScript(const TLu
     return Result;
 }
 
-std::shared_ptr<TLuaResult> TLuaEngine::StateThreadData::EnqueueFunctionCallFromCustomEvent(const sol::object& FunctionObject, const std::vector<TLuaValue>& Args, const std::string& EventName, CallStrategy Strategy) {
+std::shared_ptr<TLuaResult> TLuaEngine::StateThreadData::EnqueueFunctionCallFromCustomEvent(const LuaFunction& FunctionObject, const std::vector<TLuaValue>& Args, const std::string& EventName, CallStrategy Strategy) {
     std::unique_lock Lock(mStateFunctionQueueMutex);
     auto Iter = mStateFunctionQueue.end();
     // TODO: Document all this
@@ -1063,7 +1067,7 @@ std::shared_ptr<TLuaResult> TLuaEngine::StateThreadData::EnqueueFunctionCallFrom
     return nullptr;
 }
 
-std::shared_ptr<TLuaResult> TLuaEngine::StateThreadData::EnqueueFunctionCall(const sol::object& FunctionObject, const std::vector<TLuaValue>& Args, const std::string& EventName) {
+std::shared_ptr<TLuaResult> TLuaEngine::StateThreadData::EnqueueFunctionCall(const LuaFunction& FunctionObject, const std::vector<TLuaValue>& Args, const std::string& EventName) {
     auto Result = std::make_shared<TLuaResult>();
     Result->StateId = mStateId;
     Result->Function = FunctionObject;
@@ -1073,8 +1077,8 @@ std::shared_ptr<TLuaResult> TLuaEngine::StateThreadData::EnqueueFunctionCall(con
     return Result;
 }
 
-void TLuaEngine::StateThreadData::RegisterEvent(const std::string& EventName, const sol::object& FunctionObject) const {
-    mEngine->RegisterEvent(EventName, mStateId, FunctionObject);
+void TLuaEngine::StateThreadData::RegisterEvent(const std::string& EventName, const LuaFunction& FunctionObject) const {
+    mEngine->RegisterEvent(EventName, mStateId,  FunctionObject);
 }
 
 void TLuaEngine::StateThreadData::operator()() {
@@ -1133,22 +1137,30 @@ void TLuaEngine::StateThreadData::operator()() {
             if (NotExpired) {
                 auto ProfStart = prof::now();
                 auto TheQueuedFunction = std::move(mStateFunctionQueue.front());
-                mStateFunctionQueue.pop_front();
+                mStateFunctionQueue.erase(mStateFunctionQueue.begin());
                 Lock.unlock();
                 auto& Result = TheQueuedFunction.Result;
                 auto Args = TheQueuedFunction.Args;
                 // TODO: Use TheQueuedFunction.EventName for errors, warnings, etc
+                auto& FnObject = TheQueuedFunction.FunctionObject;
                 Result->StateId = mStateId;
+                std::lock_guard LuaLock(mEngine->mLuaStatesMutex);
                 sol::state_view StateView(mState);
-
-                auto Fn = sol::function();
-                if (TheQueuedFunction.FunctionObject.is<std::string>()) {
-                        Fn = StateView[TheQueuedFunction.FunctionObject];
-                }else {
-                        Fn = TheQueuedFunction.FunctionObject;
+                auto Fn = sol::main_protected_function();
+                std::string profileName;
+                if (std::holds_alternative<std::string>(FnObject)) {
+                    std::string name = std::get<std::string>(FnObject);
+                    beammp_debug("Function call name: " + name);
+                    Fn = StateView[name];
+                    profileName = name;
+                } else {
+                    Fn = std::get<sol::main_protected_function>(FnObject);
+                    profileName = "[lua anonymous function]";
                 }
+
+                std::vector<sol::object> LuaArgs;
+
                 if (Fn.valid() && Fn.get_type() == sol::type::function) {
-                    std::vector<sol::object> LuaArgs;
                     for (const auto& Arg : Args) {
                         if (Arg.valueless_by_exception()) {
                             continue;
@@ -1182,7 +1194,7 @@ void TLuaEngine::StateThreadData::operator()() {
                             break;
                         }
                     }
-                    auto Res = Fn(sol::as_args(LuaArgs));
+                    auto Res = Fn.call<>(sol::as_args(LuaArgs));
                     if (Res.valid()) {
                         Result->Error = false;
                         Result->Result = std::move(Res);
@@ -1191,20 +1203,16 @@ void TLuaEngine::StateThreadData::operator()() {
                         sol::error Err = Res;
                         Result->ErrorMessage = Err.what();
                     }
-                    Result->MarkAsReady();
                 } else {
                     Result->Error = true;
                     Result->ErrorMessage = BeamMPFnNotFoundError; // special error kind that we can ignore later
-                    Result->MarkAsReady();
                 }
+                Result->MarkAsReady();
+                LuaArgs.clear();
+                lua_settop(mState, 0);
+
                 auto ProfEnd = prof::now();
                 auto ProfDuration = prof::duration(ProfStart, ProfEnd);
-                std::string profileName;
-                if (TheQueuedFunction.FunctionObject.is<std::string>()) {
-                    profileName = TheQueuedFunction.FunctionObject.as<std::string>();
-                } else {
-                    profileName = "[lua anonymous function]";
-                }
                 mProfile.add_sample(profileName, ProfDuration);
             }
         }

--- a/src/TLuaEngine.cpp
+++ b/src/TLuaEngine.cpp
@@ -861,8 +861,21 @@ TLuaEngine::StateThreadData::StateThreadData(const std::string& Name, TLuaStateI
     });
     MPTable.set_function("GetOSName", &LuaAPI::MP::GetOSName);
     MPTable.set_function("GetServerVersion", &LuaAPI::MP::GetServerVersion);
-    MPTable.set_function("RegisterEvent", [this](const std::string& EventName, sol::main_protected_function FunctionObject) {
-      RegisterEvent(EventName, std::make_shared<sol::main_protected_function>(std::move(FunctionObject)));
+    MPTable.set_function("RegisterEvent", [this](const std::string& EventName, sol::object FunctionObject) {
+        LuaFunction handler;
+        bool valid = false;
+        if (FunctionObject.is<std::string>()) {
+            handler = FunctionObject.as<std::string>();
+            valid = true;
+        }
+        else if (FunctionObject.is<sol::function>()) {
+            auto ptr = std::make_shared<sol::main_protected_function>(FunctionObject.as<sol::main_protected_function>());
+            handler = std::move(ptr);
+            valid = true;
+        }
+        if (valid) {
+            RegisterEvent(EventName, std::move(handler));
+        }
     });
     MPTable.set_function("TriggerGlobalEvent", [&](const std::string& EventName, sol::variadic_args EventArgs) -> sol::table {
         return Lua_TriggerGlobalEvent(EventName, EventArgs);

--- a/src/TLuaEngine.cpp
+++ b/src/TLuaEngine.cpp
@@ -183,9 +183,21 @@ TLuaStateId TLuaEngine::GetStateIDForPlugin(const fs::path& PluginPath) {
 }
 
 void TLuaEngine::ClearEventsForState(const std::string& StateID) {
-    std::unique_lock Lock(mLuaEventsMutex);
-    for (auto& StateMap : mLuaEvents | std::views::values) {
-        StateMap.erase(StateID);
+    {
+        std::unique_lock Lock(mLuaEventsMutex);
+        for (auto& StateMap : mLuaEvents | std::views::values) {
+            StateMap.erase(StateID);
+        }
+    }
+    {
+        std::unique_lock Lock(mTimedEventsMutex);
+        for (auto it = mTimedEvents.begin(); it != mTimedEvents.end();) {
+            if (it->StateId == StateID) {
+                it = mTimedEvents.erase(it);
+            } else {
+                ++it;
+            }
+        }
     }
 }
 
@@ -449,7 +461,7 @@ void TLuaEngine::RegisterEvent(const std::string& EventName, TLuaStateId StateId
     }
 }
 
-std::vector<std::variant<sol::basic_protected_function<sol::basic_reference<true>>, std::string>> TLuaEngine::GetEventHandlersForState(const std::string& EventName, TLuaStateId StateId) {
+std::vector<std::variant<std::shared_ptr<sol::basic_protected_function<sol::basic_reference<true>>>, std::string>> TLuaEngine::GetEventHandlersForState(const std::string& EventName, TLuaStateId StateId) {
     return mLuaEvents[EventName][StateId];
 }
 
@@ -496,7 +508,12 @@ sol::table TLuaEngine::StateThreadData::Lua_TriggerGlobalEvent(const std::string
 
     sol::variadic_results LocalArgs = JsonStringToArray(Str);
     for (const auto& Handler : MyHandlers) {
-        auto Fn = mStateView[Handler];
+        auto Fn = sol::function();
+        if (std::holds_alternative<std::string>(Handler)) {
+            Fn = mStateView[std::get<std::string>(Handler)];
+        }else {
+            Fn = *std::get<std::shared_ptr<sol::main_protected_function>>(Handler);
+        }
         if (Fn.valid()) {
             auto LuaResult = Fn(LocalArgs);
             auto Result = std::make_shared<TLuaResult>();
@@ -546,17 +563,20 @@ sol::table TLuaEngine::StateThreadData::Lua_TriggerLocalEvent(const std::string&
     // TODO: make asynchronous?
     sol::table Result = mStateView.create_table();
     int i = 1;
-    for (const auto& Handler : mEngine->GetEventHandlersForState(EventName, mStateId)) {
+    const auto Handlers = mEngine->GetEventHandlersForState(EventName, mStateId);
+    for (const auto& Handler : Handlers) {
         auto Fn = sol::function();
         if (std::holds_alternative<std::string>(Handler)) {
             Fn = mStateView[std::get<std::string>(Handler)];
         }else {
-            Fn = std::get<sol::main_protected_function>(Handler);
+            Fn = *std::get<std::shared_ptr<sol::main_protected_function>>(Handler);
         }
         if (Fn.valid() && Fn.get_type() == sol::type::function) {
             auto FnRet = Fn(EventArgs);
             if (FnRet.valid()) {
-                Result.set(i, FnRet);
+                if (FnRet.return_count() > 0) {
+                    Result.set(i, FnRet.get<sol::object>());
+                }
                 ++i;
             } else {
                 sol::error Err = FnRet;
@@ -841,8 +861,8 @@ TLuaEngine::StateThreadData::StateThreadData(const std::string& Name, TLuaStateI
     });
     MPTable.set_function("GetOSName", &LuaAPI::MP::GetOSName);
     MPTable.set_function("GetServerVersion", &LuaAPI::MP::GetServerVersion);
-    MPTable.set_function("RegisterEvent", [this](const std::string& EventName, const LuaFunction& FunctionObject) {
-        RegisterEvent(EventName, FunctionObject);
+    MPTable.set_function("RegisterEvent", [this](const std::string& EventName, sol::main_protected_function FunctionObject) {
+      RegisterEvent(EventName, std::make_shared<sol::main_protected_function>(std::move(FunctionObject)));
     });
     MPTable.set_function("TriggerGlobalEvent", [&](const std::string& EventName, sol::variadic_args EventArgs) -> sol::table {
         return Lua_TriggerGlobalEvent(EventName, EventArgs);
@@ -1062,8 +1082,9 @@ std::shared_ptr<TLuaResult> TLuaEngine::StateThreadData::EnqueueFunctionCallFrom
     // TODO: Document all this
     if (Strategy == CallStrategy::BestEffort) {
         Iter = std::find_if(mStateFunctionQueue.begin(), mStateFunctionQueue.end(),
-            [&EventName](const QueuedFunction& Element) {
-                return Element.EventName == EventName;
+            [&EventName, &FunctionObject](const QueuedFunction& Element) {
+                return Element.EventName == EventName
+                    && Element.FunctionObject == FunctionObject;
             });
     }
     if (Iter == mStateFunctionQueue.end()) {
@@ -1094,13 +1115,20 @@ void TLuaEngine::StateThreadData::RegisterEvent(const std::string& EventName, co
 void TLuaEngine::StateThreadData::operator()() {
     RegisterThread("Lua:" + mStateId);
     while (!Application::IsShuttingDown()) {
-        { // StateExecuteQueue Scope
-            std::unique_lock Lock(mStateExecuteQueueMutex);
-            if (!mStateExecuteQueue.empty()) {
-                auto S = mStateExecuteQueue.front();
-                mStateExecuteQueue.pop();
-                Lock.unlock();
+        {
+            using ItemType = std::remove_reference_t<decltype(mStateExecuteQueue.front())>;
+            std::optional<ItemType> S;
 
+            { // StateExecuteQueue Scope
+                std::unique_lock Lock(mStateExecuteQueueMutex);
+                if (!mStateExecuteQueue.empty()) {
+                    S = std::move(mStateExecuteQueue.front());
+                    mStateExecuteQueue.pop();
+                }
+            }
+
+            if (S.has_value()) {
+                std::lock_guard StateLock(mEngine->mLuaStatesMutex);
                 { // Paths Scope
                     std::unique_lock PathLock(mPathsMutex);
                     if (!mPaths.empty()) {
@@ -1123,20 +1151,24 @@ void TLuaEngine::StateThreadData::operator()() {
                         auto PackageTable = StateView.globals().get<sol::table>("package");
                         PackageTable["path"] = PackageTable.get<std::string>("path") + PathAdditions.str();
                         PackageTable["cpath"] = PackageTable.get<std::string>("cpath") + CPathAdditions.str();
-                        StateView.globals()["package"] = PackageTable;
                     }
                 }
                 sol::state_view StateView(mState);
-                auto Res = StateView.safe_script(*S.first.Content, sol::script_pass_on_error, S.first.FileName);
+                auto Res = StateView.safe_script(*S->first.Content, sol::script_pass_on_error, S->first.FileName);
                 if (Res.valid()) {
-                    S.second->Error = false;
-                    S.second->Result = std::move(Res);
+                    S->second->Error = false;
+                    if (Res.return_count() > 0) {
+                        S->second->Result = std::move(Res);
+                    }
                 } else {
-                    S.second->Error = true;
-                    sol::error Err = Res;
-                    S.second->ErrorMessage = Err.what();
+                    if (lua_gettop(mState) > 0) {
+                        if (sol::stack_object err_obj(mState, -1); err_obj.is<std::string>()) {
+                            S->second->ErrorMessage = err_obj.as<std::string>();
+                        }
+                    }
                 }
-                S.second->MarkAsReady();
+                lua_settop(mState, 0);
+                S->second->MarkAsReady();
             }
         }
         { // StateFunctionQueue Scope
@@ -1149,27 +1181,28 @@ void TLuaEngine::StateThreadData::operator()() {
                 auto TheQueuedFunction = std::move(mStateFunctionQueue.front());
                 mStateFunctionQueue.erase(mStateFunctionQueue.begin());
                 Lock.unlock();
-                auto& Result = TheQueuedFunction.Result;
-                auto Args = TheQueuedFunction.Args;
-                // TODO: Use TheQueuedFunction.EventName for errors, warnings, etc
-                auto& FnObject = TheQueuedFunction.FunctionObject;
-                Result->StateId = mStateId;
+
                 std::lock_guard LuaLock(mEngine->mLuaStatesMutex);
                 sol::state_view StateView(mState);
-                auto Fn = sol::main_protected_function();
+
+                auto& Result = TheQueuedFunction.Result;
+                auto& Args = TheQueuedFunction.Args;
+                auto& FnObject = TheQueuedFunction.FunctionObject;
+                Result->StateId = mStateId;
+                lua_settop(mState, 0);
+                sol::main_protected_function Fn;
                 std::string profileName;
                 if (std::holds_alternative<std::string>(FnObject)) {
-                    std::string name = std::get<std::string>(FnObject);
+                    auto name = std::get<std::string>(FnObject);
                     Fn = StateView[name];
                     profileName = name;
                 } else {
-                    Fn = std::get<sol::main_protected_function>(FnObject);
+                    Fn = *std::get<std::shared_ptr<sol::main_protected_function>>(FnObject);
                     profileName = "[lua anonymous function]";
                 }
 
-                std::vector<sol::object> LuaArgs;
-
                 if (Fn.valid() && Fn.get_type() == sol::type::function) {
+                    std::vector<sol::object> LuaArgs;
                     for (const auto& Arg : Args) {
                         if (Arg.valueless_by_exception()) {
                             continue;
@@ -1208,16 +1241,17 @@ void TLuaEngine::StateThreadData::operator()() {
                         Result->Error = false;
                         Result->Result = std::move(Res);
                     } else {
-                        Result->Error = true;
-                        sol::error Err = Res;
-                        Result->ErrorMessage = Err.what();
+                        if (lua_gettop(mState) > 0) {
+                            if (sol::stack_object err_obj(mState, -1); err_obj.is<std::string>()) {
+                                Result->ErrorMessage = err_obj.as<std::string>();
+                            }
+                        }
                     }
                 } else {
                     Result->Error = true;
                     Result->ErrorMessage = BeamMPFnNotFoundError; // special error kind that we can ignore later
                 }
                 Result->MarkAsReady();
-                LuaArgs.clear();
                 lua_settop(mState, 0);
 
                 auto ProfEnd = prof::now();
@@ -1227,7 +1261,6 @@ void TLuaEngine::StateThreadData::operator()() {
         }
     }
 }
-
 std::queue<std::pair<TLuaChunk, std::shared_ptr<TLuaResult>>> TLuaEngine::StateThreadData::Debug_GetStateExecuteQueue() {
     std::unique_lock Lock(mStateExecuteQueueMutex);
     return mStateExecuteQueue;

--- a/src/TLuaEngine.cpp
+++ b/src/TLuaEngine.cpp
@@ -182,6 +182,13 @@ TLuaStateId TLuaEngine::GetStateIDForPlugin(const fs::path& PluginPath) {
     return "";
 }
 
+void TLuaEngine::ClearEventsForState(const std::string& StateID) {
+    std::unique_lock Lock(mLuaEventsMutex);
+    for (auto& StateMap : mLuaEvents | std::views::values) {
+        StateMap.erase(StateID);
+    }
+}
+
 void TLuaEngine::AddResultToCheck(const std::shared_ptr<TLuaResult>& Result) {
     std::unique_lock Lock(mResultsToCheckMutex);
     mResultsToCheck.push_back(Result);
@@ -436,7 +443,10 @@ void TLuaEngine::EnsureStateExists(TLuaStateId StateId, const std::string& Name,
 
 void TLuaEngine::RegisterEvent(const std::string& EventName, TLuaStateId StateId, const LuaFunction& FunctionObject) {
     std::unique_lock Lock(mLuaEventsMutex);
-    mLuaEvents[EventName][StateId].push_back(std::move(FunctionObject));
+    auto& Events = mLuaEvents[EventName][StateId];
+    if (const auto it = std::find(Events.begin(), Events.end(), FunctionObject); it == Events.end()) {
+        Events.push_back(std::move(FunctionObject));
+    }
 }
 
 std::vector<std::variant<sol::basic_protected_function<sol::basic_reference<true>>, std::string>> TLuaEngine::GetEventHandlersForState(const std::string& EventName, TLuaStateId StateId) {

--- a/src/TLuaEngine.cpp
+++ b/src/TLuaEngine.cpp
@@ -831,7 +831,7 @@ TLuaEngine::StateThreadData::StateThreadData(const std::string& Name, TLuaStateI
     });
     MPTable.set_function("GetOSName", &LuaAPI::MP::GetOSName);
     MPTable.set_function("GetServerVersion", &LuaAPI::MP::GetServerVersion);
-    MPTable.set_function("RegisterEvent", [this](const std::string& EventName, const sol::main_object& FunctionObject) {
+    MPTable.set_function("RegisterEvent", [this](const std::string& EventName, const LuaFunction& FunctionObject) {
         RegisterEvent(EventName, FunctionObject);
     });
     MPTable.set_function("TriggerGlobalEvent", [&](const std::string& EventName, sol::variadic_args EventArgs) -> sol::table {
@@ -1150,7 +1150,6 @@ void TLuaEngine::StateThreadData::operator()() {
                 std::string profileName;
                 if (std::holds_alternative<std::string>(FnObject)) {
                     std::string name = std::get<std::string>(FnObject);
-                    beammp_debug("Function call name: " + name);
                     Fn = StateView[name];
                     profileName = name;
                 } else {

--- a/src/TLuaEngine.cpp
+++ b/src/TLuaEngine.cpp
@@ -1179,7 +1179,7 @@ void TLuaEngine::StateThreadData::operator()() {
             if (NotExpired) {
                 auto ProfStart = prof::now();
                 auto TheQueuedFunction = std::move(mStateFunctionQueue.front());
-                mStateFunctionQueue.erase(mStateFunctionQueue.begin());
+                mStateFunctionQueue.pop_front();
                 Lock.unlock();
 
                 std::lock_guard LuaLock(mEngine->mLuaStatesMutex);

--- a/src/TPluginMonitor.cpp
+++ b/src/TPluginMonitor.cpp
@@ -67,6 +67,7 @@ void TPluginMonitor::operator()() {
                             FileStream.read(Contents->data(), Contents->size());
                             TLuaChunk Chunk(Contents, Pair.first, fs::path(Pair.first).parent_path().string());
                             auto StateID = mEngine->GetStateIDForPlugin(fs::path(Pair.first).parent_path());
+                            mEngine->ClearEventsForState(StateID);
                             auto Res = mEngine->EnqueueScript(StateID, Chunk);
                             Res->WaitUntilReady();
                             if (Res->Error) {


### PR DESCRIPTION
This PR implements the usage of the function directly inside RegisterEvent() while keeping the possibility of using the function name.
```lua
MP.RegisterEvent("Test",function()
Util.LogInfo("TEST")
end)
MP.TriggerLocalEvent("Test")
```
This needed A LOT of changes; since I'm still a beginner in C++, there are probably a couple of issues that I would be happy to fix (can't imagine that there aren't any).

If this gets merged, it would be better to merge it before #473 to prevent conflicts regarding the ``DontCallOnInit`` variable that isn't completely removed in this PR but is in #473.

ofc, I tested every changeand it seemed to work well (im just not sure about the ``queued`` lua console cmd)

Closes #449 
Closes #441 the panichandler is fixed in this PR
---

By creating this pull request, I understand that code that is AI generated or otherwise automatically generated may be rejected without further discussion.
I declare that I fully understand all code I pushed into this PR, and wrote all this code myself and own the rights to this code.
