### PR TITLE
Harden malformed vehicle packet parsing

### DIFF
--- a/src/TNetwork.cpp
+++ b/src/TNetwork.cpp
@@ -670,7 +670,13 @@ void TNetwork::TCPClient(const std::weak_ptr<TClient>& c) {
             Client->Disconnect("TCPRcv failed");
             break;
         }
-        mServer.GlobalParser(c, std::move(res), mPPSMonitor, *this, false);
+        try {
+            mServer.GlobalParser(c, std::move(res), mPPSMonitor, *this, false);
+        } catch (const std::exception& e) {
+            beammp_warnf("Failed to receive/parse packet via TCP from client {}: {}", Client->GetID(), e.what());
+            Client->Disconnect("Failed to parse packet");
+            break;
+        }
     }
 
     if (QueueSync.joinable())

--- a/src/TServer.cpp
+++ b/src/TServer.cpp
@@ -54,16 +54,6 @@ static std::optional<std::pair<int, int>> GetPidVid(const std::string& str) {
     }
     return std::nullopt;
 }
-
-static std::optional<std::string> ExtractStructuredPayload(const std::string& PacketData, char BeginMarker) {
-    auto FoundPos = PacketData.find(BeginMarker);
-    if (FoundPos == std::string::npos) {
-        return std::nullopt;
-    }
-
-    return PacketData.substr(FoundPos);
-}
-
 TEST_CASE("GetPidVid") {
     SUBCASE("Valid singledigit") {
         const auto MaybePidVid = GetPidVid("0-1");
@@ -130,14 +120,6 @@ TEST_CASE("GetPidVid") {
         CHECK(!MaybePidVid);
     }
 }
-
-TEST_CASE("ExtractStructuredPayload") {
-    CHECK_EQ(ExtractStructuredPayload("1-2:{\"reset\":true}", '{').value(), "{\"reset\":true}");
-    CHECK_EQ(ExtractStructuredPayload("1-2:[0,1,2,3]", '[').value(), "[0,1,2,3]");
-    CHECK_FALSE(ExtractStructuredPayload("1-2:null", '{').has_value());
-    CHECK_FALSE(ExtractStructuredPayload("1-2:null", '[').has_value());
-}
-
 TServer::TServer(const std::vector<std::string_view>& Arguments) {
     beammp_info("BeamMP Server v" + Application::ServerVersionString());
     Application::SetSubsystemStatus("Server", Application::Status::Starting);
@@ -489,13 +471,13 @@ void TServer::ParseVehicle(TClient& c, const std::string& Pckt, TNetwork& Networ
         }
 
         if (PID != -1 && VID != -1 && PID == c.GetID()) {
-            auto ResetData = ExtractStructuredPayload(Data, '{');
-            if (!ResetData.has_value()) {
-                beammp_warnf("Malformed 'Or' packet from client {}: missing '{{' in '{}'", c.GetID(), Packet);
+            auto BracketPos = Data.find('{');
+            if (BracketPos == std::string::npos) {
+                beammp_debugf("Invalid 'Or' packet body from client {}", c.GetID());
                 return;
             }
 
-            Data = std::move(ResetData.value());
+            Data = Data.substr(BracketPos);
             LuaAPI::MP::Engine->ReportErrors(LuaAPI::MP::Engine->TriggerEvent("onVehicleReset", "", c.GetID(), VID, Data));
             Network.SendToAll(&c, StringToVector(Packet), false, true);
         }
@@ -524,13 +506,14 @@ void TServer::ParseVehicle(TClient& c, const std::string& Pckt, TNetwork& Networ
         }
 
         if (PID != -1 && VID != -1 && PID == c.GetID()) {
-            auto PaintData = ExtractStructuredPayload(Data, '[');
-            if (!PaintData.has_value()) {
-                beammp_warnf("Malformed 'Op' packet from client {}: missing '[' in '{}'", c.GetID(), Packet);
+            auto BracketPos = Data.find('[');
+            if (BracketPos == std::string::npos) {
+                beammp_debugf("Invalid 'Op' packet body from client {}", c.GetID());
                 return;
             }
 
-            Data = std::move(PaintData.value());
+            Data = Data.substr(BracketPos);
+
             LuaAPI::MP::Engine->ReportErrors(LuaAPI::MP::Engine->TriggerEvent("onVehiclePaintChanged", "", c.GetID(), VID, Data));
             Network.SendToAll(&c, StringToVector(Packet), false, true);
 

--- a/src/TServer.cpp
+++ b/src/TServer.cpp
@@ -28,6 +28,7 @@
 #include <any>
 #include <optional>
 #include <sstream>
+#include <utility>
 
 #include <nlohmann/json.hpp>
 
@@ -52,6 +53,15 @@ static std::optional<std::pair<int, int>> GetPidVid(const std::string& str) {
         }
     }
     return std::nullopt;
+}
+
+static std::optional<std::string> ExtractStructuredPayload(const std::string& PacketData, char BeginMarker) {
+    auto FoundPos = PacketData.find(BeginMarker);
+    if (FoundPos == std::string::npos) {
+        return std::nullopt;
+    }
+
+    return PacketData.substr(FoundPos);
 }
 
 TEST_CASE("GetPidVid") {
@@ -119,6 +129,13 @@ TEST_CASE("GetPidVid") {
         const auto MaybePidVid = GetPidVid("0-x");
         CHECK(!MaybePidVid);
     }
+}
+
+TEST_CASE("ExtractStructuredPayload") {
+    CHECK_EQ(ExtractStructuredPayload("1-2:{\"reset\":true}", '{').value(), "{\"reset\":true}");
+    CHECK_EQ(ExtractStructuredPayload("1-2:[0,1,2,3]", '[').value(), "[0,1,2,3]");
+    CHECK_FALSE(ExtractStructuredPayload("1-2:null", '{').has_value());
+    CHECK_FALSE(ExtractStructuredPayload("1-2:null", '[').has_value());
 }
 
 TServer::TServer(const std::vector<std::string_view>& Arguments) {
@@ -472,7 +489,13 @@ void TServer::ParseVehicle(TClient& c, const std::string& Pckt, TNetwork& Networ
         }
 
         if (PID != -1 && VID != -1 && PID == c.GetID()) {
-            Data = Data.substr(Data.find('{'));
+            auto ResetData = ExtractStructuredPayload(Data, '{');
+            if (!ResetData.has_value()) {
+                beammp_warnf("Malformed 'Or' packet from client {}: missing '{{' in '{}'", c.GetID(), Packet);
+                return;
+            }
+
+            Data = std::move(ResetData.value());
             LuaAPI::MP::Engine->ReportErrors(LuaAPI::MP::Engine->TriggerEvent("onVehicleReset", "", c.GetID(), VID, Data));
             Network.SendToAll(&c, StringToVector(Packet), false, true);
         }
@@ -501,7 +524,13 @@ void TServer::ParseVehicle(TClient& c, const std::string& Pckt, TNetwork& Networ
         }
 
         if (PID != -1 && VID != -1 && PID == c.GetID()) {
-            Data = Data.substr(Data.find('['));
+            auto PaintData = ExtractStructuredPayload(Data, '[');
+            if (!PaintData.has_value()) {
+                beammp_warnf("Malformed 'Op' packet from client {}: missing '[' in '{}'", c.GetID(), Packet);
+                return;
+            }
+
+            Data = std::move(PaintData.value());
             LuaAPI::MP::Engine->ReportErrors(LuaAPI::MP::Engine->TriggerEvent("onVehiclePaintChanged", "", c.GetID(), VID, Data));
             Network.SendToAll(&c, StringToVector(Packet), false, true);
 


### PR DESCRIPTION
## Summary
Reject malformed vehicle reset and paint packets before slicing structured payloads, and catch parser exceptions in the TCP client loop.

## Problem
Or:<pid>-<vid>:null and similarly malformed Op packets could reach substr(npos) in ParseVehicle, throwing std::out_of_range. On TCP, that exception could escape the client loop and kill the thread.

## Changes
- Guard Or reset packets when no { payload exists
- Guard Op paint packets when no [ payload exists
- Add a small helper and unit test for structured payload extraction
- Catch std::exception around GlobalParser in the TCP client loop and disconnect the offending client

## Verification
- git diff --check
- Full build/tests not run in this shell because cmake was not installed