### PR TITLE
 Add unreliable (UDP) event support

### DIFF
--- a/include/LuaAPI.h
+++ b/include/LuaAPI.h
@@ -32,6 +32,8 @@ namespace MP {
     std::tuple<int, int, int> GetServerVersion();
     std::pair<bool, std::string> TriggerClientEvent(int PlayerID, const std::string& EventName, const sol::object& Data);
     std::pair<bool, std::string> TriggerClientEventJson(int PlayerID, const std::string& EventName, const sol::table& Data);
+    std::pair<bool, std::string> TriggerClientEventUnreliable(int PlayerID, const std::string& EventName, const sol::object& Data);
+    std::pair<bool, std::string> TriggerClientEventJsonUnreliable(int PlayerID, const std::string& EventName, const sol::table& Data);
     inline size_t GetPlayerCount() { return Engine->Server().ClientCount(); }
     std::pair<bool, std::string> DropPlayer(int ID, std::optional<std::string> MaybeReason);
     std::pair<bool, std::string> SendChatMessage(int ID, const std::string& Message, const bool& LogChat = true);

--- a/src/LuaAPI.cpp
+++ b/src/LuaAPI.cpp
@@ -136,10 +136,10 @@ TEST_CASE("LuaAPI::MP::GetServerVersion") {
     CHECK(pa == real.patch);
 }
 
-static inline std::pair<bool, std::string> InternalTriggerClientEvent(int PlayerID, const std::string& EventName, const std::string& Data) {
-    std::string Packet = "E:" + EventName + ":" + Data;
+static inline std::pair<bool, std::string> InternalTriggerClientEvent(int PlayerID, const std::string& EventName, const std::string& Data, bool Rel) {
+    std::string Packet = std::string(Rel ? "E:" : "e:") + EventName + ":" + Data;
     if (PlayerID == -1) {
-        LuaAPI::MP::Engine->Network().SendToAll(nullptr, StringToVector(Packet), true, true);
+        LuaAPI::MP::Engine->Network().SendToAll(nullptr, StringToVector(Packet), true, Rel);
         return { true, "" };
     } else {
         auto MaybeClient = GetClient(LuaAPI::MP::Engine->Server(), PlayerID);
@@ -149,7 +149,7 @@ static inline std::pair<bool, std::string> InternalTriggerClientEvent(int Player
                     return { false, "Player hasn't joined yet" };
                 }
 
-                if (!LuaAPI::MP::Engine->Network().Respond(*c, StringToVector(Packet), true)) {
+                if (!LuaAPI::MP::Engine->Network().Respond(*c, StringToVector(Packet), Rel)) {
                     beammp_lua_errorf("Respond failed, dropping client {}", PlayerID);
                     LuaAPI::MP::Engine->Network().ClientKick(*c, "Disconnected after failing to receive packets");
                     return { false, "Respond failed, dropping client" };
@@ -165,7 +165,12 @@ static inline std::pair<bool, std::string> InternalTriggerClientEvent(int Player
 
 std::pair<bool, std::string> LuaAPI::MP::TriggerClientEvent(int PlayerID, const std::string& EventName, const sol::object& DataObj) {
     std::string Data = DataObj.as<std::string>();
-    return InternalTriggerClientEvent(PlayerID, EventName, Data);
+    return InternalTriggerClientEvent(PlayerID, EventName, Data, true);
+}
+
+std::pair<bool, std::string> LuaAPI::MP::TriggerClientEventUnreliable(int PlayerID, const std::string& EventName, const sol::object& DataObj) {
+    std::string Data = DataObj.as<std::string>();
+    return InternalTriggerClientEvent(PlayerID, EventName, Data, false);
 }
 
 std::pair<bool, std::string> LuaAPI::MP::DropPlayer(int ID, std::optional<std::string> MaybeReason) {
@@ -865,5 +870,9 @@ std::string LuaAPI::MP::JsonUnflatten(const std::string& json) {
 }
 
 std::pair<bool, std::string> LuaAPI::MP::TriggerClientEventJson(int PlayerID, const std::string& EventName, const sol::table& Data) {
-    return InternalTriggerClientEvent(PlayerID, EventName, JsonEncode(Data));
+    return InternalTriggerClientEvent(PlayerID, EventName, JsonEncode(Data), true);
+}
+
+std::pair<bool, std::string> LuaAPI::MP::TriggerClientEventJsonUnreliable(int PlayerID, const std::string& EventName, const sol::table& Data) {
+    return InternalTriggerClientEvent(PlayerID, EventName, JsonEncode(Data), false);
 }

--- a/src/TLuaEngine.cpp
+++ b/src/TLuaEngine.cpp
@@ -922,6 +922,8 @@ TLuaEngine::StateThreadData::StateThreadData(const std::string& Name, TLuaStateI
     });
     MPTable.set_function("TriggerClientEvent", &LuaAPI::MP::TriggerClientEvent);
     MPTable.set_function("TriggerClientEventJson", &LuaAPI::MP::TriggerClientEventJson);
+    MPTable.set_function("TriggerClientEventUnreliable", &LuaAPI::MP::TriggerClientEventUnreliable);
+    MPTable.set_function("TriggerClientEventJsonUnreliable", &LuaAPI::MP::TriggerClientEventJsonUnreliable);
     MPTable.set_function("GetPlayerCount", &LuaAPI::MP::GetPlayerCount);
     MPTable.set_function("IsPlayerConnected", &LuaAPI::MP::IsPlayerConnected);
     MPTable.set_function("GetPlayerIDByName", [&](const std::string& Name) -> int {

--- a/src/TServer.cpp
+++ b/src/TServer.cpp
@@ -286,6 +286,9 @@ void TServer::GlobalParser(const std::weak_ptr<TClient>& Client, std::vector<uin
             beammp_debugf("Received 'E' packet over UDP from client '{}' ({}), ignoring it", LockedClient->GetName(), LockedClient->GetID());
             return;
         }
+        // 'E' (reliable) and 'e' (unreliable) both route through HandleEvent
+        [[fallthrough]];
+    case 'e':
         HandleEvent(*LockedClient, StringPacket);
         return;
     case 'N':


### PR DESCRIPTION
Adds an unreliable counterpart to the existing reliable event system, allowing mods to send events over UDP instead of TCP.

### New API

**Server-side Lua:**
- `MP.TriggerClientEventUnreliable(PlayerID, EventName, Data)` — UDP delivery
- `MP.TriggerClientEventJsonUnreliable(PlayerID, EventName, Data)` — JSON variant

**Client-side Lua:**
- `TriggerServerEventUnreliable(EventName, Data)` — sends `e:EventName:Data` to server

### How it works

Reliable events use `E` (uppercase) as the packet prefix, unreliable use `e` (lowercase). Both follow the same code path — the only difference is TCP vs UDP transport.

The launcher skips the >1KB compressed-size TCP upgrade for `e` packets so they stay on UDP regardless of payload size.

### Why

The existing event system only supports reliable delivery. This forces TCP retransmission for every event, which is unnecessary overhead for data that doesn't need guaranteed delivery. This adds the option to opt into UDP where appropriate.

See also: BeamMP/BeamMP-Launcher#253, BeamMP/BeamMP#892