### PR TITLE
Fix silent truncation of UDP datagrams over 1024 bytes

### DIFF
--- a/src/TNetwork.cpp
+++ b/src/TNetwork.cpp
@@ -1356,7 +1356,10 @@ bool TNetwork::UDPSend(TClient& Client, std::vector<uint8_t> Data) {
 }
 
 std::vector<uint8_t> TNetwork::UDPRcvFromClient(boost::asio::ip::udp::endpoint& ClientEndpoint) {
-    std::array<char, 1024> Ret { };
+    // Sized to the UDP maximum: recvfrom() truncates a datagram that exceeds the buffer
+    // (the tail is silently lost). A compressed position packet from a client with several
+    // moving vehicles can exceed 1024 bytes, so such updates were silently dropped.
+    std::array<char, 65535> Ret { };
     boost::system::error_code ec;
     const auto Rcv = mUDPSock.receive_from(boost::asio::mutable_buffer(Ret.data(), Ret.size()), ClientEndpoint, 0, ec);
     if (ec) {


### PR DESCRIPTION
### Problem

`TNetwork::UDPRcvFromClient` receives into a fixed `std::array<char, 1024>`. UDP `recvfrom()` **truncates** any datagram larger than the buffer — the tail is silently lost. A compressed (`ABG:`) position packet from a client with several moving vehicles can exceed 1 KB, so those updates were silently dropped (the truncated payload fails to decompress/parse), and other players saw those vehicles stutter or warp.

### Fix

Size the receive buffer to the UDP maximum (65535). One-line change plus a comment; the function already returns only the received byte count, so there is no behavior change for small datagrams.

### How this was found

Diagnosed while profiling remote-vehicle drift on a LAN fork of BeamMP (position updates from multi-vehicle clients disappearing under load); the fix has been running in that fork for weeks of sessions.

### Transparency

This fix comes from an AI-assisted fork: the bug was found and the patch written with the help of an AI coding tool (Claude), then tested by a human in real multiplayer sessions. Given this project's policy on AI-generated code, it's submitted as a **draft** for the maintainers to decide — happy to close it if that's not wanted, or for a maintainer to re-implement the one-liner independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
