### PR TITLE
DeComp(): make the grow step actually double + guard empty input

### DIFF
--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -398,6 +398,13 @@ static constexpr size_t MAX_DECOMPRESSION_BUFFER_SIZE = 30 * 1024 * 1024;
 std::vector<uint8_t> DeComp(std::span<const uint8_t> input) {
     beammp_debugf("got {} bytes of input data", input.size());
 
+    // An empty body (e.g. a bare 4-byte "ABG:" frame) can never decompress into anything; reject it
+    // up front. NOTE: this guard is required for the capped doubling below to be safe -- with a
+    // 0-size buffer, 0 * 2 stays 0 and the loop would never terminate.
+    if (input.empty()) {
+        throw std::runtime_error("empty compressed input");
+    }
+
     // start with a decompression buffer of 5x the input size, clamped to a maximum of 15 MB.
     // this buffer can and will grow, but we don't want to start it too large. A 5x compression ratio
     // is pretty optimistic.
@@ -420,8 +427,12 @@ std::vector<uint8_t> DeComp(std::span<const uint8_t> input) {
             if (output_buffer.size() >= MAX_DECOMPRESSION_BUFFER_SIZE) {
                 throw std::runtime_error(fmt::format("decompressed packet size of {} bytes exceeded", MAX_DECOMPRESSION_BUFFER_SIZE));
             }
-            // if decompression fails, we double the buffer size (up to the allowed limit) and try again
-            output_buffer.resize(std::max<size_t>(output_buffer.size() * 2, MAX_DECOMPRESSION_BUFFER_SIZE));
+            // if decompression fails, we double the buffer size (up to the allowed limit) and try again.
+            // Must be std::min: with std::max the buffer jumps straight to the 30 MB cap on the first
+            // retry (size * 2 is almost always < the cap), so every packet that needed one grow
+            // allocated the full 30 MB instead of doubling as the comment above intends. The >= cap
+            // check above still terminates the loop.
+            output_buffer.resize(std::min<size_t>(output_buffer.size() * 2, MAX_DECOMPRESSION_BUFFER_SIZE));
             beammp_warnf("zlib uncompress() failed, trying with a larger buffer size of {}", output_buffer.size());
             output_size = output_buffer.size();
         } else if (res != Z_OK) {


### PR DESCRIPTION
### Problem

The grow step in `DeComp()` (`src/Common.cpp`) doesn't do what its comment says:

```cpp
// if decompression fails, we double the buffer size (up to the allowed limit) and try again
output_buffer.resize(std::max<size_t>(output_buffer.size() * 2, MAX_DECOMPRESSION_BUFFER_SIZE));
```

`std::max(size * 2, 30MB)` is almost always 30 MB, so **every packet that needs one grow allocates the full 30 MB** instead of doubling — on every such packet, on the hot receive path. The intended capped doubling is `std::min`.

### Fix

- Change the grow to `std::min<size_t>(output_buffer.size() * 2, MAX_DECOMPRESSION_BUFFER_SIZE)` so it actually doubles up to the cap (the existing `>=` cap check above still terminates the loop).
- Add an **empty-input guard** (throws, same error path as other invalid inputs). This is *required* for the min-fix to be safe: with `std::min`, a zero-length body (e.g. a bare 4-byte `ABG:` frame from a buggy/malicious peer) would keep the buffer at 0 forever (`0 * 2` stays 0) and spin the loop — today's `std::max` is accidentally the only thing preventing that. The guard also skips a pointless 30 MB allocation + two `uncompress` calls for input that can never decompress.

The two changes are intentionally in one commit because each alone changes the safety story: `min` without the guard introduces an infinite loop; the guard without `min` leaves the 30 MB-per-grow over-allocation.

### How this was found

Found while auditing decompression robustness on a LAN fork of BeamMP (the launcher's `DeComp` has the unguarded-doubling variant of this bug, submitted separately as BeamMP-Launcher#257); the equivalent fix has been running in that fork's server for weeks of sessions.

### Transparency

This fix comes from an AI-assisted fork: the bug was found and the patch written with the help of an AI coding tool (Claude), then tested by a human in real multiplayer sessions. Given this project's policy on AI-generated code, it's submitted as a **draft** for the maintainers to decide — happy to close it if that's not wanted, or for a maintainer to re-implement it independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
