### PR TITLE
Fix server hang/crash on shutdown (#491)

### DIFF
--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -66,7 +66,7 @@ void Application::GracefullyShutdown() {
         beammp_info("Subsystem " + std::to_string(i + 1) + "/" + std::to_string(mShutdownHandlers.size()) + " shutting down");
         mShutdownHandlers[i]();
     }
-    // std::exit(-1);
+    std::_Exit(0);
 }
 
 std::string Application::ServerVersionString() {


### PR DESCRIPTION
I run my server on Pelican and kept having to force-kill it on shutdown (same as [#491](https://github.com/BeamMP/BeamMP-Server/issues/491)). It finishes shutting down all its subsystems and prints Shutdown., then just hangs. One time instead of hanging it crashed with this:

```
terminate called after throwing an instance of 'std::logic_error'
  what():  Undefined key accessed in Settings::getAsBool
```

There's a commented-out std::exit at the end of GracefullyShutdown() that looked like it was meant to handle this, so I tried exiting there with std::_Exit(0) after the shutdown handlers run. That makes it shut down instantly and cleanly for me now.

I'm not a C++ dev so I might be missing the deeper cause. Traced it with some help from AI, but I reproduced and tested the fix on my own server.

Fixes [#491].